### PR TITLE
Revert v0.5.6 scoring window regression, release v0.5.7 (fixes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.6] - 2026-04-02
+## [0.5.7] - 2026-04-02
+
+### Fixed
+
+- **Revert v0.5.6 adaptive scoring window**: The adaptive `n/2` window from v0.5.6 fixed 50 outlier series but regressed overall M4 accuracy (MAE 177→191, mean gap 12%→37%). Reverted to v0.5.5's fixed 500-observation window which gives the best overall accuracy/speed tradeoff.
+
+## [0.5.6] - 2026-04-02 [YANKED]
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.5.6"
+anofox-forecast = "0.5.7"
 ```
 
 ### Optional Features

--- a/src/models/arima/model.rs
+++ b/src/models/arima/model.rs
@@ -331,13 +331,10 @@ impl ARIMA {
         }
 
         // ARMA(p,q) scoring: CSS optimization with AICc.
-        // For long series, use approximate scoring on the tail
-        // (matching R's auto.arima approximation=TRUE). Adaptive window:
-        // use at least n/2 observations (capped at 1500) to preserve
-        // scoring quality for long seasonal series.
-        let approx_window = (n / 2).clamp(200, 1500);
-        let score_series = if n > approx_window {
-            &diff_series[n - approx_window..]
+        // For long series (n > 500), use approximate scoring on the tail
+        // (matching R's auto.arima approximation=TRUE).
+        let score_series = if n > 500 {
+            &diff_series[n - 500..]
         } else {
             diff_series
         };
@@ -2096,12 +2093,10 @@ impl SARIMA {
         }
 
         // For long series, use approximate scoring on the tail (matches R's approximation=TRUE).
-        // Adaptive window: use n/2 (capped at 1500) to preserve seasonal scoring quality.
         let n_full = diff_series.len();
         let min_approx_len = start + 200;
-        let approx_window = (n_full / 2).clamp(min_approx_len, 1500);
-        let score_series = if n_full > approx_window {
-            &diff_series[n_full - approx_window..]
+        let score_series = if n_full > min_approx_len && n_full > 500 {
+            &diff_series[n_full - 500.max(min_approx_len)..]
         } else {
             diff_series
         };


### PR DESCRIPTION
## Problem

v0.5.6's adaptive `n/2` scoring window fixed 50 outlier series but regressed overall M4 accuracy: MAE 177→191, mean gap 12%→37%.

## Fix

Revert to v0.5.5's fixed 500-observation window. Best overall tradeoff: MAE 177.27 (+4% vs statsforecast), 183ms sequential.

Closes #63.

## Test plan
- [x] 104 tests pass, 3/4 order selection, 10/10 Python validation
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)