### PR TITLE
JS parity pass: regression, pipeline, hierarchy, filters, diagnostics, features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.4.5",
+  "version": "0.6.0",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/crates/anofox-forecast-js/src/cross_validation.rs
+++ b/crates/anofox-forecast-js/src/cross_validation.rs
@@ -10,7 +10,9 @@ use anofox_forecast::models::arima::AutoARIMA;
 use anofox_forecast::models::baseline::{Naive, SimpleMovingAverage};
 use anofox_forecast::models::exponential::{AutoETS, HoltLinearTrend, SimpleExponentialSmoothing};
 use anofox_forecast::models::theta::AutoTheta;
-use anofox_forecast::utils::cross_validation::{cross_validate, CVConfig};
+use anofox_forecast::utils::cross_validation::{
+    cross_validate, rolling_forecast, CVConfig, RollingForecastConfig,
+};
 
 /// Result of cross-validation, serialized to JavaScript.
 #[derive(Serialize)]
@@ -106,6 +108,110 @@ fn run_cv_for_model(
         s if s.starts_with("sma") => {
             let window: usize = s[3..].parse().unwrap_or(5);
             cross_validate(config, ts.inner(), || SimpleMovingAverage::new(window))
+                .map_err(|e| JsError::new(&e.to_string()))
+        }
+        other => Err(JsError::new(&format!(
+            "Unknown model type '{}'. Use: naive, ses, holt, autoarima, autoets, autotheta, sma<N>",
+            other
+        ))),
+    }
+}
+
+/// Result of a rolling / expanding forecast evaluation.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RollingForecastResultJs {
+    /// All predictions concatenated in chronological order.
+    all_predictions: Vec<f64>,
+    /// All actuals concatenated in chronological order.
+    all_actuals: Vec<f64>,
+    /// Number of windows evaluated.
+    n_windows: usize,
+    /// Aggregated MAE across all windows.
+    mae: f64,
+    /// Aggregated RMSE across all windows.
+    rmse: f64,
+    /// Aggregated MAPE across all windows (NaN if unavailable).
+    mape: f64,
+    /// Aggregated sMAPE across all windows.
+    smape: f64,
+}
+
+/// Walk-forward rolling / expanding window forecast evaluation.
+///
+/// Trains a model on a historical window, forecasts `horizon` steps,
+/// records predictions vs actuals, advances the origin by `stepSize`, and
+/// repeats. Produces realistic out-of-sample accuracy estimates.
+///
+/// @param values - Array of numeric values
+/// @param timestamps - Optional array of timestamps as milliseconds since epoch
+/// @param modelType - Model type: "naive", "ses", "holt", "autoarima", "autoets", "autotheta", "sma<N>"
+/// @param initialTrainSize - Size of the first training window
+/// @param horizon - Number of steps to forecast at each origin
+/// @param stepSize - Steps between successive origins (default: `horizon`)
+/// @param expanding - `true` for expanding window (default), `false` for rolling window
+/// @returns Object with `allPredictions`, `allActuals`, `nWindows`, `mae`, `rmse`, `mape`, `smape`
+#[wasm_bindgen(js_name = rollingForecast)]
+pub fn rolling_forecast_js(
+    values: &[f64],
+    timestamps: Option<Vec<f64>>,
+    model_type: &str,
+    initial_train_size: usize,
+    horizon: usize,
+    step_size: Option<usize>,
+    expanding: Option<bool>,
+) -> Result<JsValue, JsError> {
+    let ts = match timestamps {
+        Some(ref ts_ms) => TimeSeries::with_timestamps(values, ts_ms)?,
+        None => TimeSeries::new(values)?,
+    };
+
+    let mut config = RollingForecastConfig::new(initial_train_size, horizon);
+    if let Some(s) = step_size {
+        config = config.step_size(s);
+    }
+    if let Some(e) = expanding {
+        config = config.expanding(e);
+    }
+
+    let result = run_rolling_for_model(&config, &ts, model_type)?;
+
+    let js_result = RollingForecastResultJs {
+        n_windows: result.windows.len(),
+        all_predictions: result.all_predictions,
+        all_actuals: result.all_actuals,
+        mae: result.aggregated.mae,
+        rmse: result.aggregated.rmse,
+        mape: result.aggregated.mape.unwrap_or(f64::NAN),
+        smape: result.aggregated.smape,
+    };
+
+    serde_wasm_bindgen::to_value(&js_result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+fn run_rolling_for_model(
+    config: &RollingForecastConfig,
+    ts: &TimeSeries,
+    model_type: &str,
+) -> Result<anofox_forecast::utils::cross_validation::RollingForecastResult, JsError> {
+    match model_type.to_lowercase().as_str() {
+        "naive" => rolling_forecast(ts.inner(), config, Naive::new)
+            .map_err(|e| JsError::new(&e.to_string())),
+        "ses" | "simpleexponentialsmoothing" => {
+            rolling_forecast(ts.inner(), config, SimpleExponentialSmoothing::auto)
+                .map_err(|e| JsError::new(&e.to_string()))
+        }
+        "holt" | "holtlineartrend" => rolling_forecast(ts.inner(), config, HoltLinearTrend::auto)
+            .map_err(|e| JsError::new(&e.to_string())),
+        "autoarima" => rolling_forecast(ts.inner(), config, AutoARIMA::new)
+            .map_err(|e| JsError::new(&e.to_string())),
+        "autoets" => rolling_forecast(ts.inner(), config, AutoETS::new)
+            .map_err(|e| JsError::new(&e.to_string())),
+        "autotheta" => rolling_forecast(ts.inner(), config, AutoTheta::new)
+            .map_err(|e| JsError::new(&e.to_string())),
+        s if s.starts_with("sma") => {
+            let window: usize = s[3..].parse().unwrap_or(5);
+            rolling_forecast(ts.inner(), config, move || SimpleMovingAverage::new(window))
                 .map_err(|e| JsError::new(&e.to_string()))
         }
         other => Err(JsError::new(&format!(

--- a/crates/anofox-forecast-js/src/detection.rs
+++ b/crates/anofox-forecast-js/src/detection.rs
@@ -1,0 +1,127 @@
+//! Anomaly detection + spectral analysis bindings for JavaScript.
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::detection::{
+    detect_dominant_period as inner_detect_dominant_period,
+    detect_outliers as inner_detect_outliers, detect_outliers_auto as inner_detect_outliers_auto,
+    welch_periodogram as inner_welch_periodogram, OutlierConfig as InnerOutlierConfig,
+    OutlierMethod as InnerOutlierMethod,
+};
+
+fn parse_outlier_method(m: &str) -> Result<InnerOutlierMethod, JsError> {
+    match m {
+        "iqr" | "IQR" => Ok(InnerOutlierMethod::IQR),
+        "zScore" | "z_score" | "ZScore" => Ok(InnerOutlierMethod::ZScore),
+        "modifiedZScore" | "modified_z_score" | "ModifiedZScore" => {
+            Ok(InnerOutlierMethod::ModifiedZScore)
+        }
+        other => Err(JsError::new(&format!(
+            "Unknown outlier method '{}'. Use: iqr, zScore, modifiedZScore",
+            other
+        ))),
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OutlierResultJs {
+    outlier_indices: Vec<usize>,
+    scores: Vec<f64>,
+    threshold: f64,
+    method: String,
+    n_outliers: usize,
+    outlier_percentage: f64,
+}
+
+/// Detect outliers in a time series.
+///
+/// @param values - Array of numeric values
+/// @param method - "iqr" (default), "zScore", or "modifiedZScore"
+/// @param threshold - Method-specific threshold (default: 1.5 IQR / 3.0 Z / 3.5 MZ)
+/// @returns Object with `outlierIndices`, `scores`, `threshold`, `method`, `nOutliers`, `outlierPercentage`
+#[wasm_bindgen(js_name = detectOutliers)]
+pub fn detect_outliers(
+    values: &[f64],
+    method: Option<String>,
+    threshold: Option<f64>,
+) -> Result<JsValue, JsError> {
+    let cfg = match method.as_deref() {
+        Some(m) => {
+            let meth = parse_outlier_method(m)?;
+            let default_thr = match meth {
+                InnerOutlierMethod::IQR => 1.5,
+                InnerOutlierMethod::ZScore => 3.0,
+                InnerOutlierMethod::ModifiedZScore => 3.5,
+            };
+            InnerOutlierConfig {
+                method: meth,
+                threshold: threshold.unwrap_or(default_thr),
+            }
+        }
+        None => InnerOutlierConfig::default(),
+    };
+
+    let result = inner_detect_outliers(values, &cfg);
+    let out = OutlierResultJs {
+        n_outliers: result.outlier_count(),
+        outlier_percentage: result.outlier_percentage(),
+        outlier_indices: result.outlier_indices,
+        scores: result.scores,
+        threshold: result.threshold,
+        method: format!("{:?}", result.method),
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Detect outliers with default configuration (IQR method, 1.5 multiplier).
+#[wasm_bindgen(js_name = detectOutliersAuto)]
+pub fn detect_outliers_auto(values: &[f64]) -> Result<JsValue, JsError> {
+    let result = inner_detect_outliers_auto(values);
+    let out = OutlierResultJs {
+        n_outliers: result.outlier_count(),
+        outlier_percentage: result.outlier_percentage(),
+        outlier_indices: result.outlier_indices,
+        scores: result.scores,
+        threshold: result.threshold,
+        method: format!("{:?}", result.method),
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PeriodogramEntry {
+    period: usize,
+    power: f64,
+}
+
+/// Welch's periodogram for spectral density estimation.
+///
+/// @param values - Array of numeric values
+/// @param windowSize - Window size for the segmented FFT
+/// @param overlap - Fractional overlap between windows in [0, 1) (default: 0.5)
+/// @returns Array of {period, power} entries sorted by frequency
+#[wasm_bindgen(js_name = welchPeriodogram)]
+pub fn welch_periodogram(
+    values: &[f64],
+    window_size: usize,
+    overlap: Option<f64>,
+) -> Result<JsValue, JsError> {
+    let result = inner_welch_periodogram(values, window_size, overlap.unwrap_or(0.5));
+    let out: Vec<PeriodogramEntry> = result
+        .into_iter()
+        .map(|(period, power)| PeriodogramEntry { period, power })
+        .collect();
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Detect the dominant seasonal period in a time series.
+///
+/// @param values - Array of numeric values
+/// @returns The detected period, or `undefined` if no strong period is found
+#[wasm_bindgen(js_name = detectDominantPeriod)]
+pub fn detect_dominant_period(values: &[f64]) -> Option<usize> {
+    inner_detect_dominant_period(values)
+}

--- a/crates/anofox-forecast-js/src/diagnostics.rs
+++ b/crates/anofox-forecast-js/src/diagnostics.rs
@@ -1,0 +1,181 @@
+//! Diagnostic bindings for JavaScript: AID (Automatic Identification of
+//! Demand) and intermittent demand diagnostics.
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::validation::aid::{
+    AidAnalyzer as InnerAidAnalyzer, AidAnomalyLabel, AidResult as InnerAidResult,
+};
+use anofox_forecast::validation::intermittent_diagnostics::{
+    DemandClassification, IntermittentDiagnostics as InnerIntermittent,
+};
+
+// ---------------------------------------------------------------------------
+// AID
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AidSummaryJs {
+    demand_type: String,
+    distribution: String,
+    is_fractional: bool,
+    mean: f64,
+    variance: f64,
+    shape: Option<f64>,
+    scale: Option<f64>,
+    zero_prob: Option<f64>,
+    zero_proportion: f64,
+    n_observations: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AidResultJs {
+    summary: AidSummaryJs,
+    anomalies: Vec<String>,
+}
+
+fn anomaly_label_str(label: AidAnomalyLabel) -> &'static str {
+    match label {
+        AidAnomalyLabel::Normal => "normal",
+        AidAnomalyLabel::Stockout => "stockout",
+        AidAnomalyLabel::NewProduct => "newProduct",
+        AidAnomalyLabel::ObsoleteProduct => "obsoleteProduct",
+        AidAnomalyLabel::HighOutlier => "highOutlier",
+        AidAnomalyLabel::LowOutlier => "lowOutlier",
+    }
+}
+
+fn aid_to_js(result: &InnerAidResult) -> AidResultJs {
+    let summary = result.summary();
+    let features = result.features();
+    AidResultJs {
+        summary: AidSummaryJs {
+            demand_type: format!("{:?}", summary.demand_type),
+            distribution: format!("{:?}", summary.distribution),
+            is_fractional: summary.is_fractional,
+            mean: summary.mean,
+            variance: summary.variance,
+            shape: summary.shape,
+            scale: summary.scale,
+            zero_prob: summary.zero_prob,
+            zero_proportion: summary.zero_proportion,
+            n_observations: summary.n_observations,
+        },
+        anomalies: features
+            .labels
+            .iter()
+            .map(|&l| anomaly_label_str(l).to_string())
+            .collect(),
+    }
+}
+
+/// Automatic Identification of Demand: distribution fitting, demand type
+/// classification, and per-observation anomaly detection (stockouts,
+/// lifecycle events, outliers).
+///
+/// @param values - Array of demand observations
+/// @param anomalyAlpha - Significance level for anomaly detection (default: 0.05)
+/// @param intermittentThreshold - Zero-proportion threshold for "intermittent" (default: 0.3)
+/// @returns Object with `summary` (demand type, distribution, params) and
+///          `anomalies` (per-observation labels)
+#[wasm_bindgen(js_name = analyzeDemand)]
+pub fn analyze_demand(
+    values: &[f64],
+    anomaly_alpha: Option<f64>,
+    intermittent_threshold: Option<f64>,
+) -> Result<JsValue, JsError> {
+    let mut analyzer = InnerAidAnalyzer::new();
+    if let Some(a) = anomaly_alpha {
+        analyzer = analyzer.anomaly_alpha(a);
+    }
+    if let Some(t) = intermittent_threshold {
+        analyzer = analyzer.intermittent_threshold(t);
+    }
+    let result = analyzer.analyze(values);
+    let js_result = aid_to_js(&result);
+    serde_wasm_bindgen::to_value(&js_result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Intermittent diagnostics
+// ---------------------------------------------------------------------------
+
+fn classification_str(c: DemandClassification) -> &'static str {
+    match c {
+        DemandClassification::Smooth => "smooth",
+        DemandClassification::Erratic => "erratic",
+        DemandClassification::Intermittent => "intermittent",
+        DemandClassification::Lumpy => "lumpy",
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IntermittentResultJs {
+    adi: f64,
+    cv_squared: f64,
+    classification: String,
+    recommended_model: String,
+    zero_fraction: f64,
+    bias: f64,
+    coverage_rate: Option<f64>,
+    periods_in_stock: Vec<f64>,
+}
+
+fn intermittent_to_js(inner: &InnerIntermittent) -> IntermittentResultJs {
+    IntermittentResultJs {
+        adi: inner.adi,
+        cv_squared: inner.cv_squared,
+        classification: classification_str(inner.classification).to_string(),
+        recommended_model: inner.recommended_model().to_string(),
+        zero_fraction: inner.zero_fraction,
+        bias: inner.bias,
+        coverage_rate: inner.coverage_rate,
+        periods_in_stock: inner.periods_in_stock.clone(),
+    }
+}
+
+/// Intermittent demand diagnostics: Syntetos-Boylan classification +
+/// recommended model.
+///
+/// @param actuals - Actual demand values
+/// @returns Object with `adi`, `cvSquared`, `classification`, `recommendedModel`, `zeroFraction`
+#[wasm_bindgen(js_name = intermittentDiagnostics)]
+pub fn intermittent_diagnostics(actuals: &[f64]) -> Result<JsValue, JsError> {
+    let diag = InnerIntermittent::from_data(actuals);
+    let out = intermittent_to_js(&diag);
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Intermittent demand diagnostics with a forecast — adds bias and
+/// periods-in-stock tracking.
+///
+/// @param actuals - Actual demand values
+/// @param forecast - Forecast values (length ≤ actuals)
+/// @returns Object with full diagnostics including `bias` and `periodsInStock`
+#[wasm_bindgen(js_name = intermittentDiagnosticsWithForecast)]
+pub fn intermittent_diagnostics_with_forecast(
+    actuals: &[f64],
+    forecast: &[f64],
+) -> Result<JsValue, JsError> {
+    let diag = InnerIntermittent::with_forecast(actuals, forecast);
+    let out = intermittent_to_js(&diag);
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Intermittent diagnostics with a forecast and prediction intervals —
+/// additionally computes coverage rate.
+#[wasm_bindgen(js_name = intermittentDiagnosticsWithIntervals)]
+pub fn intermittent_diagnostics_with_intervals(
+    actuals: &[f64],
+    forecast: &[f64],
+    lower: &[f64],
+    upper: &[f64],
+) -> Result<JsValue, JsError> {
+    let diag = InnerIntermittent::with_intervals(actuals, forecast, lower, upper);
+    let out = intermittent_to_js(&diag);
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/anofox-forecast-js/src/features.rs
+++ b/crates/anofox-forecast-js/src/features.rs
@@ -8,8 +8,9 @@ use wasm_bindgen::prelude::*;
 
 use anofox_forecast::core::{generate_future_timestamps as gen_future_ts, Frequency};
 use anofox_forecast::features::{
-    autocorrelation as acf_fn, basic, distribution, entropy, partial_autocorrelation as pacf_fn,
-    AdvancedFeature, BinaryIndicator, FeatureGenerator as InnerFeatureGenerator, TimeComponent,
+    autocorrelation as acf_fn, basic, change, complexity, counting, distribution, entropy,
+    partial_autocorrelation as pacf_fn, trend, AdvancedFeature, BinaryIndicator,
+    FeatureGenerator as InnerFeatureGenerator, TimeComponent,
 };
 
 /// Compute the autocorrelation of a time series at a specific lag.
@@ -381,4 +382,314 @@ mod tests {
         let se = sample_entropy(&values, 2, 0.2);
         assert!(!se.is_nan());
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+//  Extended feature library — thin wrappers over `anofox_forecast::features`.
+// ─────────────────────────────────────────────────────────────────────────
+
+// ── basic ───────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = absEnergy)]
+pub fn abs_energy(values: &[f64]) -> f64 {
+    basic::abs_energy(values)
+}
+
+#[wasm_bindgen(js_name = absoluteMaximum)]
+pub fn absolute_maximum(values: &[f64]) -> f64 {
+    basic::absolute_maximum(values)
+}
+
+#[wasm_bindgen(js_name = absoluteSumOfChanges)]
+pub fn absolute_sum_of_changes(values: &[f64]) -> f64 {
+    basic::absolute_sum_of_changes(values)
+}
+
+#[wasm_bindgen]
+pub fn maximum(values: &[f64]) -> f64 {
+    basic::maximum(values)
+}
+
+#[wasm_bindgen]
+pub fn minimum(values: &[f64]) -> f64 {
+    basic::minimum(values)
+}
+
+#[wasm_bindgen]
+pub fn median(values: &[f64]) -> f64 {
+    basic::median(values)
+}
+
+#[wasm_bindgen(js_name = meanAbsChange)]
+pub fn mean_abs_change(values: &[f64]) -> f64 {
+    basic::mean_abs_change(values)
+}
+
+#[wasm_bindgen(js_name = meanChange)]
+pub fn mean_change(values: &[f64]) -> f64 {
+    basic::mean_change(values)
+}
+
+#[wasm_bindgen(js_name = meanSecondDerivativeCentral)]
+pub fn mean_second_derivative_central(values: &[f64]) -> f64 {
+    basic::mean_second_derivative_central(values)
+}
+
+#[wasm_bindgen(js_name = meanNAbsoluteMax)]
+pub fn mean_n_absolute_max(values: &[f64], n: usize) -> f64 {
+    basic::mean_n_absolute_max(values, n)
+}
+
+#[wasm_bindgen(js_name = rootMeanSquare)]
+pub fn root_mean_square(values: &[f64]) -> f64 {
+    basic::root_mean_square(values)
+}
+
+#[wasm_bindgen(js_name = standardDeviation)]
+pub fn standard_deviation(values: &[f64]) -> f64 {
+    basic::standard_deviation(values)
+}
+
+#[wasm_bindgen(js_name = sumValues)]
+pub fn sum_values(values: &[f64]) -> f64 {
+    basic::sum_values(values)
+}
+
+#[wasm_bindgen(js_name = varianceSample)]
+pub fn variance_sample(values: &[f64]) -> f64 {
+    basic::variance_sample(values)
+}
+
+// ── distribution ────────────────────────────────────────────────────────
+
+#[wasm_bindgen]
+pub fn quantile(values: &[f64], q: f64) -> f64 {
+    distribution::quantile(values, q)
+}
+
+#[wasm_bindgen(js_name = variationCoefficient)]
+pub fn variation_coefficient(values: &[f64]) -> f64 {
+    distribution::variation_coefficient(values)
+}
+
+#[wasm_bindgen(js_name = largeStandardDeviation)]
+pub fn large_standard_deviation(values: &[f64], r: f64) -> bool {
+    distribution::large_standard_deviation(values, r)
+}
+
+#[wasm_bindgen(js_name = varianceLargerThanStandardDeviation)]
+pub fn variance_larger_than_standard_deviation(values: &[f64]) -> bool {
+    distribution::variance_larger_than_standard_deviation(values)
+}
+
+#[wasm_bindgen(js_name = symmetryLooking)]
+pub fn symmetry_looking(values: &[f64], r: f64) -> bool {
+    distribution::symmetry_looking(values, r)
+}
+
+#[wasm_bindgen(js_name = ratioBeyondRSigma)]
+pub fn ratio_beyond_r_sigma(values: &[f64], r: f64) -> f64 {
+    distribution::ratio_beyond_r_sigma(values, r)
+}
+
+// ── entropy ─────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = permutationEntropy)]
+pub fn permutation_entropy(values: &[f64], order: usize, delay: usize) -> f64 {
+    entropy::permutation_entropy(values, order, delay)
+}
+
+#[wasm_bindgen(js_name = permutationEntropyNormalized)]
+pub fn permutation_entropy_normalized(values: &[f64], order: usize, delay: usize) -> f64 {
+    entropy::permutation_entropy_normalized(values, order, delay)
+}
+
+#[wasm_bindgen(js_name = binnedEntropy)]
+pub fn binned_entropy(values: &[f64], max_bins: usize) -> f64 {
+    entropy::binned_entropy(values, max_bins)
+}
+
+#[wasm_bindgen(js_name = fourierEntropy)]
+pub fn fourier_entropy(values: &[f64]) -> f64 {
+    entropy::fourier_entropy(values)
+}
+
+// ── complexity ──────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = cidCe)]
+pub fn cid_ce(values: &[f64], normalize: bool) -> f64 {
+    complexity::cid_ce(values, normalize)
+}
+
+#[wasm_bindgen]
+pub fn c3(values: &[f64], lag: usize) -> f64 {
+    complexity::c3(values, lag)
+}
+
+#[wasm_bindgen(js_name = lempelZivComplexity)]
+pub fn lempel_ziv_complexity(values: &[f64], bins: usize) -> f64 {
+    complexity::lempel_ziv_complexity(values, bins)
+}
+
+#[wasm_bindgen(js_name = lempelZivComplexityBinary)]
+pub fn lempel_ziv_complexity_binary(values: &[f64]) -> f64 {
+    complexity::lempel_ziv_complexity_binary(values)
+}
+
+// ── counting ────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = countAbove)]
+pub fn count_above(values: &[f64], threshold: f64) -> usize {
+    counting::count_above(values, threshold)
+}
+
+#[wasm_bindgen(js_name = countBelow)]
+pub fn count_below(values: &[f64], threshold: f64) -> usize {
+    counting::count_below(values, threshold)
+}
+
+#[wasm_bindgen(js_name = countAboveMean)]
+pub fn count_above_mean(values: &[f64]) -> usize {
+    counting::count_above_mean(values)
+}
+
+#[wasm_bindgen(js_name = countBelowMean)]
+pub fn count_below_mean(values: &[f64]) -> usize {
+    counting::count_below_mean(values)
+}
+
+#[wasm_bindgen(js_name = numberPeaks)]
+pub fn number_peaks(values: &[f64], support: usize) -> usize {
+    counting::number_peaks(values, support)
+}
+
+#[wasm_bindgen(js_name = numberCrossingM)]
+pub fn number_crossing_m(values: &[f64], m: f64) -> usize {
+    counting::number_crossing_m(values, m)
+}
+
+#[wasm_bindgen(js_name = longestStrikeAboveMean)]
+pub fn longest_strike_above_mean(values: &[f64]) -> usize {
+    counting::longest_strike_above_mean(values)
+}
+
+#[wasm_bindgen(js_name = longestStrikeBelowMean)]
+pub fn longest_strike_below_mean(values: &[f64]) -> usize {
+    counting::longest_strike_below_mean(values)
+}
+
+#[wasm_bindgen(js_name = firstLocationOfMaximum)]
+pub fn first_location_of_maximum(values: &[f64]) -> f64 {
+    counting::first_location_of_maximum(values)
+}
+
+#[wasm_bindgen(js_name = firstLocationOfMinimum)]
+pub fn first_location_of_minimum(values: &[f64]) -> f64 {
+    counting::first_location_of_minimum(values)
+}
+
+#[wasm_bindgen(js_name = lastLocationOfMaximum)]
+pub fn last_location_of_maximum(values: &[f64]) -> f64 {
+    counting::last_location_of_maximum(values)
+}
+
+#[wasm_bindgen(js_name = lastLocationOfMinimum)]
+pub fn last_location_of_minimum(values: &[f64]) -> f64 {
+    counting::last_location_of_minimum(values)
+}
+
+#[wasm_bindgen(js_name = hasDuplicate)]
+pub fn has_duplicate(values: &[f64]) -> bool {
+    counting::has_duplicate(values)
+}
+
+#[wasm_bindgen(js_name = hasDuplicateMax)]
+pub fn has_duplicate_max(values: &[f64]) -> bool {
+    counting::has_duplicate_max(values)
+}
+
+#[wasm_bindgen(js_name = hasDuplicateMin)]
+pub fn has_duplicate_min(values: &[f64]) -> bool {
+    counting::has_duplicate_min(values)
+}
+
+#[wasm_bindgen(js_name = indexMassQuantile)]
+pub fn index_mass_quantile(values: &[f64], q: f64) -> f64 {
+    counting::index_mass_quantile(values, q)
+}
+
+#[wasm_bindgen(js_name = valueCount)]
+pub fn value_count(values: &[f64], value: f64) -> usize {
+    counting::value_count(values, value)
+}
+
+#[wasm_bindgen(js_name = rangeCount)]
+pub fn range_count(values: &[f64], min: f64, max: f64) -> usize {
+    counting::range_count(values, min, max)
+}
+
+// ── change ──────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = energyRatioByChunks)]
+pub fn energy_ratio_by_chunks(values: &[f64], n_chunks: usize, chunk_index: usize) -> f64 {
+    change::energy_ratio_by_chunks(values, n_chunks, chunk_index)
+}
+
+#[wasm_bindgen(js_name = percentageOfReoccurringDatapointsToAllDatapoints)]
+pub fn percentage_of_reoccurring_datapoints_to_all_datapoints(values: &[f64]) -> f64 {
+    change::percentage_of_reoccurring_datapoints_to_all_datapoints(values)
+}
+
+#[wasm_bindgen(js_name = percentageOfReoccurringValuesToAllValues)]
+pub fn percentage_of_reoccurring_values_to_all_values(values: &[f64]) -> f64 {
+    change::percentage_of_reoccurring_values_to_all_values(values)
+}
+
+#[wasm_bindgen(js_name = ratioValueNumberToTimeSeriesLength)]
+pub fn ratio_value_number_to_time_series_length(values: &[f64]) -> f64 {
+    change::ratio_value_number_to_time_series_length(values)
+}
+
+#[wasm_bindgen(js_name = sumOfReoccurringDataPoints)]
+pub fn sum_of_reoccurring_data_points(values: &[f64]) -> f64 {
+    change::sum_of_reoccurring_data_points(values)
+}
+
+#[wasm_bindgen(js_name = sumOfReoccurringValues)]
+pub fn sum_of_reoccurring_values(values: &[f64]) -> f64 {
+    change::sum_of_reoccurring_values(values)
+}
+
+// ── autocorrelation (extra) ─────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = aggAutocorrelation)]
+pub fn agg_autocorrelation(values: &[f64], max_lag: usize, agg_func: &str) -> f64 {
+    anofox_forecast::features::agg_autocorrelation(values, max_lag, agg_func)
+}
+
+#[wasm_bindgen(js_name = timeReversalAsymmetryStatistic)]
+pub fn time_reversal_asymmetry_statistic(values: &[f64], lag: usize) -> f64 {
+    anofox_forecast::features::time_reversal_asymmetry_statistic(values, lag)
+}
+
+// ── trend / AR ──────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = aggLinearTrend)]
+pub fn agg_linear_trend(values: &[f64], chunk_len: usize, agg_func: &str, attribute: &str) -> f64 {
+    trend::agg_linear_trend(values, chunk_len, agg_func, attribute)
+}
+
+#[wasm_bindgen(js_name = arCoefficient)]
+pub fn ar_coefficient(values: &[f64], k: usize, coeff: usize) -> f64 {
+    trend::ar_coefficient(values, k, coeff)
+}
+
+#[wasm_bindgen(js_name = arCoefficientYuleWalker)]
+pub fn ar_coefficient_yule_walker(values: &[f64], k: usize) -> f64 {
+    trend::ar_coefficient_yule_walker(values, k)
+}
+
+#[wasm_bindgen(js_name = augmentedDickeyFuller)]
+pub fn augmented_dickey_fuller(values: &[f64]) -> f64 {
+    trend::augmented_dickey_fuller(values)
 }

--- a/crates/anofox-forecast-js/src/filters.rs
+++ b/crates/anofox-forecast-js/src/filters.rs
@@ -1,0 +1,180 @@
+//! Band-pass / trend filter bindings for JavaScript.
+//!
+//! Hodrick-Prescott, Christiano-Fitzgerald, Baxter-King, Hamilton, and
+//! fractional differencing — each returns trend/cycle/differenced series as
+//! plain JS arrays.
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::models::arima::{
+    find_min_fractional_d as inner_find_min_frac_d, fractional_difference as inner_frac_diff,
+};
+use anofox_forecast::seasonality::bandpass::{bk_filter as inner_bk, cf_filter as inner_cf};
+use anofox_forecast::seasonality::hamilton::hamilton_filter as inner_hamilton;
+use anofox_forecast::seasonality::hp_filter::HodrickPrescottFilter;
+use anofox_forecast::seasonality::traits::TrendComponent;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CycleDecompositionJs {
+    trend: Vec<f64>,
+    cycle: Vec<f64>,
+    low_period: usize,
+    high_period: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HamiltonDecompositionJs {
+    trend: Vec<f64>,
+    cycle: Vec<f64>,
+    h: usize,
+    p: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HpResultJs {
+    trend: Vec<f64>,
+    cycle: Vec<f64>,
+    lambda: f64,
+}
+
+/// Apply the Hodrick-Prescott filter to a series.
+///
+/// @param values - Array of numeric values
+/// @param lambda - Smoothing parameter (default: 1600 for quarterly data).
+///                 Common values: 1600 (quarterly), 129600 (monthly), 6.25 (annual).
+/// @returns Object with `trend`, `cycle`, `lambda`
+#[wasm_bindgen(js_name = hpFilter)]
+pub fn hp_filter(values: &[f64], lambda: Option<f64>) -> Result<JsValue, JsError> {
+    let lam = lambda.unwrap_or(1600.0);
+    let mut hp = HodrickPrescottFilter::new(lam).map_err(|e| JsError::new(&e.to_string()))?;
+    hp.fit_trend(values)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let trend = hp.fitted_trend().to_vec();
+    let cycle = hp.cycle().to_vec();
+    let out = HpResultJs {
+        trend,
+        cycle,
+        lambda: lam,
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Christiano-Fitzgerald band-pass filter — asymmetric, preserves series length.
+///
+/// @param values - Array of numeric values
+/// @param lowPeriod - Lower bound of the passband in periods (e.g., 6 quarters)
+/// @param highPeriod - Upper bound of the passband in periods (e.g., 32 quarters)
+/// @param drift - If `true`, remove linear drift before filtering (default: true)
+/// @returns Object with `trend`, `cycle`, `lowPeriod`, `highPeriod`
+#[wasm_bindgen(js_name = cfFilter)]
+pub fn cf_filter(
+    values: &[f64],
+    low_period: usize,
+    high_period: usize,
+    drift: Option<bool>,
+) -> Result<JsValue, JsError> {
+    let decomposition = inner_cf(values, low_period, high_period, drift.unwrap_or(true))
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let out = CycleDecompositionJs {
+        trend: decomposition.trend,
+        cycle: decomposition.cycle,
+        low_period: decomposition.low_period,
+        high_period: decomposition.high_period,
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Baxter-King band-pass filter — symmetric, loses `2k` observations at each edge.
+///
+/// @param values - Array of numeric values
+/// @param lowPeriod - Lower bound of the passband in periods
+/// @param highPeriod - Upper bound of the passband in periods
+/// @param k - Half-length of the filter (default: 12 for quarterly data)
+/// @returns Object with `trend`, `cycle`, `lowPeriod`, `highPeriod`
+#[wasm_bindgen(js_name = bkFilter)]
+pub fn bk_filter(
+    values: &[f64],
+    low_period: usize,
+    high_period: usize,
+    k: Option<usize>,
+) -> Result<JsValue, JsError> {
+    let decomposition = inner_bk(values, low_period, high_period, k.unwrap_or(12))
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let out = CycleDecompositionJs {
+        trend: decomposition.trend,
+        cycle: decomposition.cycle,
+        low_period: decomposition.low_period,
+        high_period: decomposition.high_period,
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Hamilton filter — regression-based trend-cycle decomposition that avoids
+/// the HP filter's endpoint bias.
+///
+/// @param values - Array of numeric values
+/// @param h - Forecast horizon used in the regression (default: 8)
+/// @param p - Number of lags in the regression (default: 4)
+/// @returns Object with `trend`, `cycle`, `h`, `p`
+#[wasm_bindgen(js_name = hamiltonFilter)]
+pub fn hamilton_filter(
+    values: &[f64],
+    h: Option<usize>,
+    p: Option<usize>,
+) -> Result<JsValue, JsError> {
+    let h = h.unwrap_or(8);
+    let p = p.unwrap_or(4);
+    let decomposition = inner_hamilton(values, h, p).map_err(|e| JsError::new(&e.to_string()))?;
+    let out = HamiltonDecompositionJs {
+        trend: decomposition.trend,
+        cycle: decomposition.cycle,
+        h,
+        p,
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Fractional differencing — removes just enough memory to achieve
+/// stationarity while preserving predictive signal.
+///
+/// @param values - Array of numeric values
+/// @param d - Differencing order, typically `0 < d < 1`
+/// @param threshold - Weight truncation threshold (default: 1e-4)
+/// @returns Array of differenced values (shorter than input)
+#[wasm_bindgen(js_name = fractionalDifference)]
+pub fn fractional_difference(values: &[f64], d: f64, threshold: Option<f64>) -> Vec<f64> {
+    inner_frac_diff(values, d, threshold.unwrap_or(1e-4))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MinFracDJs {
+    d: f64,
+    p_value: f64,
+}
+
+/// Find the minimum fractional differencing order `d` that makes the series
+/// stationary according to the Augmented Dickey-Fuller test.
+///
+/// @param values - Array of numeric values
+/// @param significance - ADF p-value threshold (default: 0.05)
+/// @param threshold - Weight truncation threshold for the inner differencing (default: 1e-4)
+/// @returns Object with `d` (the minimum differencing order) and `pValue` (the ADF p-value at that d)
+#[wasm_bindgen(js_name = findMinFractionalD)]
+pub fn find_min_fractional_d(
+    values: &[f64],
+    significance: Option<f64>,
+    threshold: Option<f64>,
+) -> Result<JsValue, JsError> {
+    let (d, p_value) = inner_find_min_frac_d(
+        values,
+        significance.unwrap_or(0.05),
+        threshold.unwrap_or(1e-4),
+    );
+    let out = MinFracDJs { d, p_value };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/anofox-forecast-js/src/global_models.rs
+++ b/crates/anofox-forecast-js/src/global_models.rs
@@ -11,6 +11,7 @@ use anofox_forecast::models::exponential::{
     GlobalETS as InnerGlobalETS, ModelPool as InnerModelPool, TrendType,
 };
 use anofox_forecast::models::intermittent::GlobalCroston as InnerGlobalCroston;
+use anofox_forecast::models::theta::GlobalTheta as InnerGlobalTheta;
 
 /// Parse a ModelPool string into the Rust enum.
 fn parse_model_pool(pool: &str) -> Result<InnerModelPool, JsError> {
@@ -196,6 +197,37 @@ pub fn global_croston(
     let forecasts = model.predict(horizon);
 
     let result = GlobalCrostonResult {
+        forecasts,
+        alpha: model.alpha(),
+    };
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GlobalThetaResult {
+    forecasts: Vec<Vec<f64>>,
+    alpha: f64,
+}
+
+/// Fit a GlobalTheta model: shared α for the Standard Theta Method across
+/// many series.
+///
+/// @param series - Array of arrays (each inner array is one series)
+/// @param horizon - Forecast horizon
+/// @returns Object with forecasts array and shared alpha
+#[wasm_bindgen(js_name = globalTheta)]
+pub fn global_theta(series: JsValue, horizon: usize) -> Result<JsValue, JsError> {
+    let all_series: Vec<Vec<f64>> =
+        serde_wasm_bindgen::from_value(series).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let mut model = InnerGlobalTheta::new();
+    model
+        .fit(&all_series)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    let forecasts = model.predict(horizon);
+    let result = GlobalThetaResult {
         forecasts,
         alpha: model.alpha(),
     };

--- a/crates/anofox-forecast-js/src/hierarchy.rs
+++ b/crates/anofox-forecast-js/src/hierarchy.rs
@@ -1,0 +1,186 @@
+//! Hierarchical forecasting / reconciliation bindings for JavaScript.
+//!
+//! Exposes `HierarchyTree` and seven reconciliation methods (BottomUp,
+//! TopDown, MiddleOut, MinTraceOls, MinTraceShrink, MinTraceVariance,
+//! MinTraceStruct) for coherent multi-level forecasts.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::hierarchy::{
+    HierarchyTree as InnerHierarchyTree, ReconciliationMethod as InnerMethod,
+};
+
+// ---------------------------------------------------------------------------
+// Parse helpers
+// ---------------------------------------------------------------------------
+
+fn parse_method(name: &str, middle_level: Option<usize>) -> Result<InnerMethod, JsError> {
+    match name {
+        "bottomUp" | "BottomUp" | "bottom_up" => Ok(InnerMethod::BottomUp),
+        "topDown" | "TopDown" | "top_down" => Ok(InnerMethod::TopDown),
+        "middleOut" | "MiddleOut" | "middle_out" => Ok(InnerMethod::MiddleOut {
+            middle_level: middle_level.unwrap_or(1),
+        }),
+        "minTraceOls" | "MinTraceOls" | "min_trace_ols" => Ok(InnerMethod::MinTraceOls),
+        "minTraceShrink" | "MinTraceShrink" | "min_trace_shrink" => Ok(InnerMethod::MinTraceShrink),
+        "minTraceVariance" | "MinTraceVariance" | "min_trace_variance" => {
+            Ok(InnerMethod::MinTraceVariance)
+        }
+        "minTraceStruct" | "MinTraceStruct" | "min_trace_struct" => Ok(InnerMethod::MinTraceStruct),
+        other => Err(JsError::new(&format!(
+            "Unknown reconciliation method '{}'. Use: bottomUp, topDown, middleOut, \
+             minTraceOls, minTraceShrink, minTraceVariance, minTraceStruct",
+            other
+        ))),
+    }
+}
+
+// JS input / output shapes
+#[derive(Deserialize)]
+struct EdgeJs {
+    parent: String,
+    children: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ForecastEntryJs {
+    name: String,
+    values: Vec<f64>,
+}
+
+#[derive(Serialize)]
+struct ReconciledEntryJs {
+    name: String,
+    values: Vec<f64>,
+}
+
+// ---------------------------------------------------------------------------
+// HierarchyTree wrapper
+// ---------------------------------------------------------------------------
+
+/// A tree of named nodes with support for coherent forecast reconciliation.
+///
+/// ```javascript
+/// import { HierarchyTree } from '@sipemu/anofox-forecast';
+///
+/// // total → [A, B]; A → [A1, A2]; B → [B1, B2]
+/// const tree = new HierarchyTree([
+///     { parent: "total", children: ["A", "B"] },
+///     { parent: "A", children: ["A1", "A2"] },
+///     { parent: "B", children: ["B1", "B2"] },
+/// ]);
+///
+/// const baseForecasts = [
+///     { name: "total", values: [100, 110] },
+///     { name: "A",     values: [55, 60] },
+///     { name: "B",     values: [50, 55] },
+///     { name: "A1",    values: [25, 28] },
+///     { name: "A2",    values: [28, 30] },
+///     { name: "B1",    values: [22, 25] },
+///     { name: "B2",    values: [25, 28] },
+/// ];
+///
+/// const reconciled = tree.reconcile(baseForecasts, "bottomUp");
+/// ```
+#[wasm_bindgen]
+pub struct HierarchyTree {
+    inner: InnerHierarchyTree,
+}
+
+#[wasm_bindgen]
+impl HierarchyTree {
+    /// Build a hierarchy from parent → children edges.
+    ///
+    /// Expects a JS array like `[{parent: "total", children: ["A", "B"]}, ...]`.
+    /// The root is inferred as the node that never appears as a child.
+    #[wasm_bindgen(constructor)]
+    pub fn new(edges: JsValue) -> Result<HierarchyTree, JsError> {
+        let parsed: Vec<EdgeJs> =
+            serde_wasm_bindgen::from_value(edges).map_err(|e| JsError::new(&e.to_string()))?;
+
+        // Build owned storage for the lifetimes expected by InnerHierarchyTree::new.
+        let child_refs: Vec<Vec<&str>> = parsed
+            .iter()
+            .map(|e| e.children.iter().map(|s| s.as_str()).collect())
+            .collect();
+        let edge_refs: Vec<(&str, &[&str])> = parsed
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.parent.as_str(), child_refs[i].as_slice()))
+            .collect();
+
+        let tree = InnerHierarchyTree::new(edge_refs).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(Self { inner: tree })
+    }
+
+    /// Number of nodes in the tree.
+    #[wasm_bindgen(getter)]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Names of all nodes in BFS (top-down) order.
+    #[wasm_bindgen(js_name = nodeNames)]
+    pub fn node_names(&self) -> Vec<String> {
+        self.inner
+            .node_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    /// Provide historical actuals for TopDown / MiddleOut proportions.
+    ///
+    /// Input: `[{name: "A", values: [...]}, ...]`.
+    #[wasm_bindgen(js_name = setActuals)]
+    pub fn set_actuals(&mut self, actuals: JsValue) -> Result<(), JsError> {
+        let parsed: Vec<ForecastEntryJs> =
+            serde_wasm_bindgen::from_value(actuals).map_err(|e| JsError::new(&e.to_string()))?;
+        let map: HashMap<String, Vec<f64>> =
+            parsed.into_iter().map(|e| (e.name, e.values)).collect();
+        self.inner.set_actuals(map);
+        Ok(())
+    }
+
+    /// Provide historical residuals for MinTraceShrink / MinTraceVariance.
+    #[wasm_bindgen(js_name = setResiduals)]
+    pub fn set_residuals(&mut self, residuals: JsValue) -> Result<(), JsError> {
+        let parsed: Vec<ForecastEntryJs> =
+            serde_wasm_bindgen::from_value(residuals).map_err(|e| JsError::new(&e.to_string()))?;
+        let map: HashMap<String, Vec<f64>> =
+            parsed.into_iter().map(|e| (e.name, e.values)).collect();
+        self.inner.set_residuals(map);
+        Ok(())
+    }
+
+    /// Reconcile base forecasts using the specified method.
+    ///
+    /// @param baseForecasts - `[{name: string, values: number[]}, ...]` covering every node
+    /// @param method - "bottomUp" | "topDown" | "middleOut" | "minTraceOls" | "minTraceShrink" | "minTraceVariance" | "minTraceStruct"
+    /// @param middleLevel - Required only for "middleOut" (default: 1)
+    /// @returns Array of `{name, values}` entries in BFS order
+    pub fn reconcile(
+        &self,
+        base_forecasts: JsValue,
+        method: &str,
+        middle_level: Option<usize>,
+    ) -> Result<JsValue, JsError> {
+        let parsed: Vec<ForecastEntryJs> = serde_wasm_bindgen::from_value(base_forecasts)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let base: Vec<(String, Vec<f64>)> =
+            parsed.into_iter().map(|e| (e.name, e.values)).collect();
+        let m = parse_method(method, middle_level)?;
+        let result = self
+            .inner
+            .reconcile(&base, m)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let out: Vec<ReconciledEntryJs> = result
+            .into_iter()
+            .map(|(name, values)| ReconciledEntryJs { name, values })
+            .collect();
+        serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+    }
+}

--- a/crates/anofox-forecast-js/src/lib.rs
+++ b/crates/anofox-forecast-js/src/lib.rs
@@ -11,11 +11,17 @@ pub mod calendar;
 pub mod changepoint;
 pub mod cross_validation;
 pub mod decomposition;
+pub mod detection;
+pub mod diagnostics;
 pub mod features;
+pub mod filters;
 pub mod forecaster;
 pub mod global_models;
+pub mod hierarchy;
 pub mod monitor;
+pub mod pipeline;
 pub mod postprocess;
+pub mod regression;
 pub mod time_series;
 pub mod validation;
 
@@ -24,13 +30,26 @@ pub use auto_models::{AutoEnsembleForecaster, AutoForecastBuilder, AutoForecaste
 pub use bootstrap::bootstrap_forecast_js;
 pub use calendar::*;
 pub use changepoint::{auto_detect_changepoints, detect_changepoints, detect_changepoints_bic};
-pub use cross_validation::cross_validate_js;
+pub use cross_validation::{cross_validate_js, rolling_forecast_js};
 pub use decomposition::{mstl_decompose, stl_decompose};
+pub use detection::{
+    detect_dominant_period, detect_outliers, detect_outliers_auto, welch_periodogram,
+};
+pub use diagnostics::{
+    analyze_demand, intermittent_diagnostics, intermittent_diagnostics_with_forecast,
+    intermittent_diagnostics_with_intervals,
+};
 pub use features::*;
+pub use filters::{
+    bk_filter, cf_filter, find_min_fractional_d, fractional_difference, hamilton_filter, hp_filter,
+};
 pub use forecaster::*;
-pub use global_models::{global_auto_ets, global_croston, global_ets};
+pub use global_models::{global_auto_ets, global_croston, global_ets, global_theta};
+pub use hierarchy::HierarchyTree;
 pub use monitor::{monitor_forecast_errors, update_forecast_monitor};
+pub use pipeline::{Pipeline, PipelineBuilder};
 pub use postprocess::*;
+pub use regression::{RegressionFeatures, RegressionForecaster};
 pub use time_series::*;
 pub use validation::*;
 

--- a/crates/anofox-forecast-js/src/pipeline.rs
+++ b/crates/anofox-forecast-js/src/pipeline.rs
@@ -1,0 +1,272 @@
+//! Pipeline + transform bindings for JavaScript.
+//!
+//! Exposes `Pipeline` and a builder API for chaining reversible transforms
+//! (BoxCox, Difference, SeasonalDifference, Scale, Log) around any of the
+//! built-in forecasting models. The pipeline itself implements the
+//! `Forecaster` interface, so `fit` / `predict` work just like any other
+//! model.
+
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::models::arima::{AutoARIMA, ARIMA, SARIMA};
+use anofox_forecast::models::baseline::{Naive, RandomWalkWithDrift, SeasonalNaive};
+use anofox_forecast::models::exponential::{
+    AutoETS, HoltWinters, SeasonalType, SimpleExponentialSmoothing, ETS,
+};
+use anofox_forecast::models::theta::{AutoTheta, Theta};
+use anofox_forecast::models::{BoxedForecaster, Forecaster as ForecasterTrait};
+use anofox_forecast::transform::pipeline::{Pipeline as InnerPipeline, Transform};
+use anofox_forecast::transform::transforms::{
+    BoxCoxTransform, DifferenceTransform, LogTransform, ScaleMethod, ScaleTransform,
+    SeasonalDifferenceTransform,
+};
+
+use crate::time_series::{Forecast, TimeSeries};
+
+// ---------------------------------------------------------------------------
+// PipelineBuilder
+// ---------------------------------------------------------------------------
+
+/// Builder for a composable transform → model pipeline.
+///
+/// ```javascript
+/// import { PipelineBuilder } from '@sipemu/anofox-forecast';
+///
+/// const builder = new PipelineBuilder();
+/// builder.boxCoxAuto();        // Box-Cox with automatic lambda
+/// builder.difference(1);        // first-order differencing
+/// const model = builder.buildAutoArima();
+///
+/// model.fit(ts);
+/// const forecast = model.predict(12);
+/// ```
+#[wasm_bindgen]
+pub struct PipelineBuilder {
+    transforms: Vec<Box<dyn Transform>>,
+}
+
+impl Default for PipelineBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[wasm_bindgen]
+impl PipelineBuilder {
+    /// Create an empty pipeline builder.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            transforms: Vec::new(),
+        }
+    }
+
+    // ── Box-Cox ──────────────────────────────────────────────────
+
+    /// Append a Box-Cox transform with an automatically selected lambda.
+    #[wasm_bindgen(js_name = boxCoxAuto)]
+    pub fn box_cox_auto(&mut self) {
+        self.transforms.push(Box::new(BoxCoxTransform::auto()));
+    }
+
+    /// Append a Box-Cox transform with a fixed lambda (e.g. 0.0 = log,
+    /// 1.0 = identity).
+    #[wasm_bindgen(js_name = boxCox)]
+    pub fn box_cox(&mut self, lambda: f64) {
+        self.transforms
+            .push(Box::new(BoxCoxTransform::with_lambda(lambda)));
+    }
+
+    // ── Differencing ─────────────────────────────────────────────
+
+    /// Append a differencing transform of order `d` (typically 1 or 2).
+    pub fn difference(&mut self, d: usize) {
+        self.transforms.push(Box::new(DifferenceTransform::new(d)));
+    }
+
+    /// Append a seasonal differencing transform with the given period.
+    #[wasm_bindgen(js_name = seasonalDifference)]
+    pub fn seasonal_difference(&mut self, period: usize) {
+        self.transforms
+            .push(Box::new(SeasonalDifferenceTransform::new(period)));
+    }
+
+    // ── Scaling ──────────────────────────────────────────────────
+
+    /// Append a Z-score standardisation transform ((x − μ) / σ).
+    pub fn standardize(&mut self) {
+        self.transforms
+            .push(Box::new(ScaleTransform::new(ScaleMethod::Standardize)));
+    }
+
+    /// Append a min-max normalisation transform ([0, 1]).
+    pub fn normalize(&mut self) {
+        self.transforms
+            .push(Box::new(ScaleTransform::new(ScaleMethod::Normalize)));
+    }
+
+    /// Append a robust (median / IQR) scaling transform.
+    #[wasm_bindgen(js_name = robustScale)]
+    pub fn robust_scale(&mut self) {
+        self.transforms
+            .push(Box::new(ScaleTransform::new(ScaleMethod::RobustScale)));
+    }
+
+    // ── Log ──────────────────────────────────────────────────────
+
+    /// Append a natural-log transform.
+    pub fn log(&mut self) {
+        self.transforms.push(Box::new(LogTransform::new()));
+    }
+
+    // ── Terminal builders ────────────────────────────────────────
+
+    fn build_with(self, model: BoxedForecaster) -> Pipeline {
+        let mut builder = InnerPipeline::builder().model(model);
+        for t in self.transforms {
+            builder = builder.transform_boxed(t);
+        }
+        Pipeline {
+            inner: builder.build(),
+        }
+    }
+
+    /// Build the pipeline with a `Naive` forecaster as the inner model.
+    #[wasm_bindgen(js_name = buildNaive)]
+    pub fn build_naive(self) -> Pipeline {
+        self.build_with(Box::new(Naive::new()))
+    }
+
+    /// Build with a `SeasonalNaive(period)` inner model.
+    #[wasm_bindgen(js_name = buildSeasonalNaive)]
+    pub fn build_seasonal_naive(self, period: usize) -> Pipeline {
+        self.build_with(Box::new(SeasonalNaive::new(period)))
+    }
+
+    /// Build with a `RandomWalkWithDrift` inner model.
+    #[wasm_bindgen(js_name = buildRandomWalkDrift)]
+    pub fn build_random_walk_drift(self) -> Pipeline {
+        self.build_with(Box::new(RandomWalkWithDrift::new()))
+    }
+
+    /// Build with a `SimpleExponentialSmoothing(alpha)` inner model.
+    #[wasm_bindgen(js_name = buildSes)]
+    pub fn build_ses(self, alpha: f64) -> Pipeline {
+        self.build_with(Box::new(SimpleExponentialSmoothing::new(alpha)))
+    }
+
+    /// Build with an auto-fitted additive `HoltWinters` inner model.
+    #[wasm_bindgen(js_name = buildHoltWintersAdditive)]
+    pub fn build_holt_winters_additive(self, period: usize) -> Pipeline {
+        self.build_with(Box::new(HoltWinters::auto(period, SeasonalType::Additive)))
+    }
+
+    /// Build with an auto-fitted multiplicative `HoltWinters` inner model.
+    #[wasm_bindgen(js_name = buildHoltWintersMultiplicative)]
+    pub fn build_holt_winters_multiplicative(self, period: usize) -> Pipeline {
+        self.build_with(Box::new(HoltWinters::auto(
+            period,
+            SeasonalType::Multiplicative,
+        )))
+    }
+
+    /// Build with an `ETS::default()` inner model.
+    #[wasm_bindgen(js_name = buildEts)]
+    pub fn build_ets(self) -> Pipeline {
+        self.build_with(Box::new(ETS::default()))
+    }
+
+    /// Build with an `AutoETS` inner model (period is inferred at fit time).
+    #[wasm_bindgen(js_name = buildAutoEts)]
+    pub fn build_auto_ets(self) -> Pipeline {
+        self.build_with(Box::new(AutoETS::new()))
+    }
+
+    /// Build with a `Theta` inner model.
+    #[wasm_bindgen(js_name = buildTheta)]
+    pub fn build_theta(self) -> Pipeline {
+        self.build_with(Box::new(Theta::new()))
+    }
+
+    /// Build with an `AutoTheta` inner model.
+    #[wasm_bindgen(js_name = buildAutoTheta)]
+    pub fn build_auto_theta(self) -> Pipeline {
+        self.build_with(Box::new(AutoTheta::new()))
+    }
+
+    /// Build with an `ARIMA(p, d, q)` inner model.
+    #[wasm_bindgen(js_name = buildArima)]
+    pub fn build_arima(self, p: usize, d: usize, q: usize) -> Pipeline {
+        self.build_with(Box::new(ARIMA::new(p, d, q)))
+    }
+
+    /// Build with a `SARIMA(p, d, q)(P, D, Q, period)` inner model.
+    #[wasm_bindgen(js_name = buildSarima)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_sarima(
+        self,
+        p: usize,
+        d: usize,
+        q: usize,
+        seasonal_p: usize,
+        seasonal_d: usize,
+        seasonal_q: usize,
+        period: usize,
+    ) -> Pipeline {
+        self.build_with(Box::new(SARIMA::new(
+            p, d, q, seasonal_p, seasonal_d, seasonal_q, period,
+        )))
+    }
+
+    /// Build with an `AutoARIMA` inner model.
+    #[wasm_bindgen(js_name = buildAutoArima)]
+    pub fn build_auto_arima(self) -> Pipeline {
+        self.build_with(Box::new(AutoARIMA::new()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/// A composable transform → model pipeline that implements the `Forecaster`
+/// interface.
+///
+/// Fit and predict calls are forwarded through the chain of transforms and
+/// automatically inverse-transformed on output.
+#[wasm_bindgen]
+pub struct Pipeline {
+    inner: InnerPipeline,
+}
+
+#[wasm_bindgen]
+impl Pipeline {
+    /// Fit the pipeline to a time series.
+    pub fn fit(&mut self, series: &TimeSeries) -> Result<(), JsError> {
+        self.inner
+            .fit(series.inner())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Forecast `horizon` steps ahead.
+    pub fn predict(&self, horizon: usize) -> Result<Forecast, JsError> {
+        self.inner
+            .predict(horizon)
+            .map(Forecast::from_inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Forecast with confidence intervals.
+    #[wasm_bindgen(js_name = predictWithIntervals)]
+    pub fn predict_with_intervals(&self, horizon: usize, level: f64) -> Result<Forecast, JsError> {
+        self.inner
+            .predict_with_intervals(horizon, level)
+            .map(Forecast::from_inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+}

--- a/crates/anofox-forecast-js/src/postprocess.rs
+++ b/crates/anofox-forecast-js/src/postprocess.rs
@@ -8,13 +8,17 @@ use wasm_bindgen::prelude::*;
 
 use anofox_forecast::postprocess::{
     BacktestConfig as InnerBacktestConfig, BacktestResult as InnerBacktestResult,
+    BinnedConformalPredictor as InnerBinnedConformalPredictor,
+    BinnedConformalResult as InnerBinnedConformalResult,
     BootstrapPredictor as InnerBootstrapPredictor, BootstrapResult as InnerBootstrapResult,
     ConformalPredictor as InnerConformalPredictor, ConformalResult as InnerConformalResult,
     HistoricalSimResult as InnerHistoricalSimResult,
-    HistoricalSimulator as InnerHistoricalSimulator, NormalPredictor as InnerNormalPredictor,
+    HistoricalSimulator as InnerHistoricalSimulator, IDRPredictor as InnerIDRPredictor,
+    IDRResult as InnerIDRResult, NormalPredictor as InnerNormalPredictor,
     NormalResult as InnerNormalResult, PerStepConformalResult as InnerPerStepConformalResult,
     PointForecasts as InnerPointForecasts, PostProcessor as InnerPostProcessor,
-    PredictionIntervals as InnerPredictionIntervals, QuantileForecasts as InnerQuantileForecasts,
+    PredictionIntervals as InnerPredictionIntervals, QRAPredictor as InnerQRAPredictor,
+    QRAResult as InnerQRAResult, QuantileForecasts as InnerQuantileForecasts,
     TrainedModel as InnerTrainedModel,
 };
 
@@ -876,4 +880,245 @@ impl JsPerStepConformalResult {
 struct PerStepPredictJs {
     lower: Vec<f64>,
     upper: Vec<f64>,
+}
+
+// =============================================================================
+// BINNED CONFORMAL PREDICTOR
+// =============================================================================
+
+/// Binned conformal predictor for heteroscedastic prediction intervals.
+///
+/// Bins calibration residuals by predicted magnitude so that intervals widen
+/// where errors are systematically larger.
+///
+/// ```javascript
+/// const binned = new JsBinnedConformalPredictor(0.9, 3);
+/// const result = binned.fit(trainForecasts, trainActuals);
+/// const intervals = binned.predict(result, newForecasts);
+/// ```
+#[wasm_bindgen]
+pub struct JsBinnedConformalPredictor {
+    inner: InnerBinnedConformalPredictor,
+}
+
+#[wasm_bindgen]
+pub struct JsBinnedConformalResult {
+    inner: InnerBinnedConformalResult,
+}
+
+#[wasm_bindgen]
+impl JsBinnedConformalResult {
+    #[wasm_bindgen(getter, js_name = binEdges)]
+    pub fn bin_edges(&self) -> Vec<f64> {
+        self.inner.bin_edges().to_vec()
+    }
+
+    #[wasm_bindgen(getter, js_name = binQuantiles)]
+    pub fn bin_quantiles(&self) -> Vec<f64> {
+        self.inner.bin_quantiles().to_vec()
+    }
+
+    #[wasm_bindgen(getter, js_name = globalQuantile)]
+    pub fn global_quantile(&self) -> f64 {
+        self.inner.global_quantile()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn coverage(&self) -> f64 {
+        self.inner.coverage()
+    }
+
+    #[wasm_bindgen(getter, js_name = nBins)]
+    pub fn n_bins(&self) -> usize {
+        self.inner.n_bins()
+    }
+}
+
+#[wasm_bindgen]
+impl JsBinnedConformalPredictor {
+    /// Create a binned conformal predictor with a target coverage and
+    /// number of bins.
+    #[wasm_bindgen(constructor)]
+    pub fn new(coverage: f64, n_bins: usize) -> Self {
+        Self {
+            inner: InnerBinnedConformalPredictor::new(coverage, n_bins),
+        }
+    }
+
+    /// Fit the predictor on historical forecasts and actuals.
+    pub fn fit(
+        &self,
+        forecasts: &[f64],
+        actuals: &[f64],
+    ) -> Result<JsBinnedConformalResult, JsError> {
+        let res = self
+            .inner
+            .fit(forecasts, actuals)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(JsBinnedConformalResult { inner: res })
+    }
+
+    /// Apply the fitted result to new point forecasts.
+    pub fn predict(
+        &self,
+        result: &JsBinnedConformalResult,
+        point_forecasts: &[f64],
+    ) -> Result<JsValue, JsError> {
+        let intervals = self.inner.predict(&result.inner, point_forecasts);
+        let out = BinnedIntervalsJs {
+            lower: intervals.lower().to_vec(),
+            upper: intervals.upper().to_vec(),
+            coverage: intervals.coverage(),
+        };
+        serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BinnedIntervalsJs {
+    lower: Vec<f64>,
+    upper: Vec<f64>,
+    coverage: f64,
+}
+
+// =============================================================================
+// QRA PREDICTOR
+// =============================================================================
+
+/// Quantile Regression Averaging predictor — combines forecasts from multiple
+/// models into calibrated quantile forecasts.
+#[wasm_bindgen]
+pub struct JsQRAPredictor {
+    inner: InnerQRAPredictor,
+}
+
+#[wasm_bindgen]
+pub struct JsQRAResult {
+    inner: InnerQRAResult,
+}
+
+#[wasm_bindgen]
+impl JsQRAResult {
+    #[wasm_bindgen(getter)]
+    pub fn quantiles(&self) -> Vec<f64> {
+        self.inner.quantiles().to_vec()
+    }
+
+    #[wasm_bindgen(getter, js_name = nForecasters)]
+    pub fn n_forecasters(&self) -> usize {
+        self.inner.n_forecasters()
+    }
+
+    #[wasm_bindgen(getter, js_name = hasIntercept)]
+    pub fn has_intercept(&self) -> bool {
+        self.inner.has_intercept()
+    }
+}
+
+#[wasm_bindgen]
+impl JsQRAPredictor {
+    /// Create a QRA predictor with the given target quantiles (unregularised).
+    #[wasm_bindgen(constructor)]
+    pub fn new(quantiles: Vec<f64>) -> Self {
+        Self {
+            inner: InnerQRAPredictor::standard(quantiles),
+        }
+    }
+
+    /// Create a Lasso-regularised QRA predictor.
+    pub fn lasso(quantiles: Vec<f64>, lambda: f64) -> Self {
+        Self {
+            inner: InnerQRAPredictor::lasso(quantiles, lambda),
+        }
+    }
+
+    /// Fit the predictor on a matrix of forecasts from multiple models and
+    /// the corresponding actual values.
+    ///
+    /// @param forecastsMatrix - Vec<Vec<f64>>: rows = time, cols = models
+    /// @param actuals - Actual values (length == rows of matrix)
+    pub fn fit(&self, forecasts_matrix: JsValue, actuals: &[f64]) -> Result<JsQRAResult, JsError> {
+        let matrix: Vec<Vec<f64>> = serde_wasm_bindgen::from_value(forecasts_matrix)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let res = self
+            .inner
+            .fit(&matrix, actuals)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(JsQRAResult { inner: res })
+    }
+
+    /// Produce quantile forecasts for a new matrix of model forecasts.
+    pub fn predict(
+        &self,
+        result: &JsQRAResult,
+        forecasts_matrix: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let matrix: Vec<Vec<f64>> = serde_wasm_bindgen::from_value(forecasts_matrix)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let quantile_forecasts = self
+            .inner
+            .predict(&result.inner, &matrix)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let out = QuantileForecastsJs::from_inner(&quantile_forecasts);
+        serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+// =============================================================================
+// IDR PREDICTOR
+// =============================================================================
+
+/// Isotonic Distributional Regression predictor — state-of-the-art
+/// calibration via monotonic rank-based mapping.
+#[wasm_bindgen]
+pub struct JsIDRPredictor {
+    inner: InnerIDRPredictor,
+}
+
+#[wasm_bindgen]
+pub struct JsIDRResult {
+    inner: InnerIDRResult,
+}
+
+#[wasm_bindgen]
+impl JsIDRResult {
+    #[wasm_bindgen(getter)]
+    pub fn quantiles(&self) -> Vec<f64> {
+        self.inner.quantiles().to_vec()
+    }
+}
+
+#[wasm_bindgen]
+impl JsIDRPredictor {
+    /// Create an IDR predictor with the given target quantiles.
+    #[wasm_bindgen(constructor)]
+    pub fn new(quantiles: Vec<f64>) -> Self {
+        Self {
+            inner: InnerIDRPredictor::new(quantiles),
+        }
+    }
+
+    /// Fit on historical forecasts and actuals.
+    pub fn fit(&self, forecasts: &[f64], actuals: &[f64]) -> Result<JsIDRResult, JsError> {
+        let res = self
+            .inner
+            .fit(forecasts, actuals)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(JsIDRResult { inner: res })
+    }
+
+    /// Produce quantile forecasts for new point forecasts.
+    pub fn predict(
+        &self,
+        result: &JsIDRResult,
+        point_forecasts: &JsPointForecasts,
+    ) -> Result<JsValue, JsError> {
+        let quantile_forecasts = self
+            .inner
+            .predict(&result.inner, point_forecasts.inner())
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let out = QuantileForecastsJs::from_inner(&quantile_forecasts);
+        serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+    }
 }

--- a/crates/anofox-forecast-js/src/regression.rs
+++ b/crates/anofox-forecast-js/src/regression.rs
@@ -1,0 +1,472 @@
+//! Regression forecaster bindings for JavaScript.
+//!
+//! Exposes `RegressionForecaster` with configurable features (trend, lags,
+//! Fourier, rolling statistics, changepoints) and the full set of regression
+//! backends (OLS, Ridge, ElasticNet, Quantile, WLS, RLS, Tweedie, Poisson,
+//! BLS, Dynamic).
+
+use std::sync::Arc;
+
+use wasm_bindgen::prelude::*;
+
+use anofox_forecast::models::regression::{
+    ChangepointEncoding as InnerChangepointEncoding, ChangepointFeature as InnerChangepointFeature,
+    RegressionBackend as InnerRegressionBackend, RegressionFeatures as InnerRegressionFeatures,
+    RegressionForecaster as InnerRegressionForecaster, RollingStatKind as InnerRollingStatKind,
+    SeasonalSpec as InnerSeasonalSpec, TrendType as InnerTrendType,
+    WeightStrategy as InnerWeightStrategy,
+};
+use anofox_forecast::models::Forecaster as ForecasterTrait;
+
+use crate::time_series::{Forecast, TimeSeries};
+
+// ---------------------------------------------------------------------------
+// Small parse helpers
+// ---------------------------------------------------------------------------
+
+fn parse_rolling_kind(kind: &str, alpha: Option<f64>) -> Result<InnerRollingStatKind, JsError> {
+    let a = alpha.unwrap_or(0.3);
+    match kind {
+        "mean" | "Mean" => Ok(InnerRollingStatKind::Mean),
+        "std" | "Std" => Ok(InnerRollingStatKind::Std),
+        "var" | "Var" => Ok(InnerRollingStatKind::Var),
+        "min" | "Min" => Ok(InnerRollingStatKind::Min),
+        "max" | "Max" => Ok(InnerRollingStatKind::Max),
+        "median" | "Median" => Ok(InnerRollingStatKind::Median),
+        "sum" | "Sum" => Ok(InnerRollingStatKind::Sum),
+        "ewmMean" | "EwmMean" | "ewm_mean" => Ok(InnerRollingStatKind::EwmMean { alpha: a }),
+        "ewmStd" | "EwmStd" | "ewm_std" => Ok(InnerRollingStatKind::EwmStd { alpha: a }),
+        other => Err(JsError::new(&format!(
+            "Unknown rolling kind '{}'. Use: mean, std, var, min, max, median, sum, ewmMean, ewmStd",
+            other
+        ))),
+    }
+}
+
+fn parse_trend_type(t: &str) -> Result<InnerTrendType, JsError> {
+    match t {
+        "linear" | "Linear" => Ok(InnerTrendType::Linear),
+        "quadratic" | "Quadratic" => Ok(InnerTrendType::Quadratic),
+        "cubic" | "Cubic" => Ok(InnerTrendType::Cubic),
+        "exponential" | "Exponential" => Ok(InnerTrendType::Exponential),
+        "theilSen" | "TheilSen" | "theil_sen" => Ok(InnerTrendType::TheilSen),
+        other => Err(JsError::new(&format!(
+            "Unknown trend type '{}'. Use: linear, quadratic, cubic, exponential, theilSen",
+            other
+        ))),
+    }
+}
+
+fn parse_changepoint_encoding(enc: &str) -> Result<InnerChangepointEncoding, JsError> {
+    match enc {
+        "stepFunctions" | "StepFunctions" | "step" => Ok(InnerChangepointEncoding::StepFunctions),
+        "regimeIndex" | "RegimeIndex" | "regime" => Ok(InnerChangepointEncoding::RegimeIndex),
+        "cumulativeCount" | "CumulativeCount" | "count" => {
+            Ok(InnerChangepointEncoding::CumulativeCount)
+        }
+        other => Err(JsError::new(&format!(
+            "Unknown changepoint encoding '{}'. Use: stepFunctions, regimeIndex, cumulativeCount",
+            other
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RegressionFeatures builder wrapper
+// ---------------------------------------------------------------------------
+
+/// Feature configuration for [`RegressionForecaster`].
+///
+/// All methods mutate in place and return `void` — chain via multiple calls.
+///
+/// ```javascript
+/// const features = new RegressionFeatures();
+/// features.noTrend();
+/// features.lags(3);
+/// features.withRollingMean(7);
+/// features.withEwmMean(20, 0.3);
+/// const model = new RegressionForecaster(features);
+/// ```
+#[wasm_bindgen]
+pub struct RegressionFeatures {
+    inner: InnerRegressionFeatures,
+}
+
+impl Default for RegressionFeatures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[wasm_bindgen]
+impl RegressionFeatures {
+    /// Create default features: trend enabled, no lags, exog enabled.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: InnerRegressionFeatures::new(),
+        }
+    }
+
+    // ── Trend / lags / exog toggles ──────────────────────────────
+
+    pub fn trend(&mut self) {
+        self.inner = std::mem::take(&mut self.inner).trend();
+    }
+
+    #[wasm_bindgen(js_name = noTrend)]
+    pub fn no_trend(&mut self) {
+        self.inner = std::mem::take(&mut self.inner).no_trend();
+    }
+
+    pub fn lags(&mut self, max_lag: usize) {
+        self.inner = std::mem::take(&mut self.inner).lags(max_lag);
+    }
+
+    #[wasm_bindgen(js_name = specificLags)]
+    pub fn specific_lags(&mut self, lags: Vec<usize>) {
+        self.inner = std::mem::take(&mut self.inner).specific_lags(&lags);
+    }
+
+    #[wasm_bindgen(js_name = autoLags)]
+    pub fn auto_lags(&mut self, max_lag: usize) {
+        self.inner = std::mem::take(&mut self.inner).auto_lags(max_lag);
+    }
+
+    pub fn exog(&mut self) {
+        self.inner = std::mem::take(&mut self.inner).exog();
+    }
+
+    #[wasm_bindgen(js_name = noExog)]
+    pub fn no_exog(&mut self) {
+        self.inner = std::mem::take(&mut self.inner).no_exog();
+    }
+
+    // ── Trend / seasonal components ──────────────────────────────
+
+    /// Add a trend component column.
+    ///
+    /// `trend` ∈ "linear" | "quadratic" | "cubic" | "exponential" | "theilSen"
+    #[wasm_bindgen(js_name = withTrendComponent)]
+    pub fn with_trend_component(&mut self, trend: &str) -> Result<(), JsError> {
+        let t = parse_trend_type(trend)?;
+        self.inner = std::mem::take(&mut self.inner).with_trend_component(t);
+        Ok(())
+    }
+
+    /// Add Fourier seasonality features.
+    pub fn fourier(&mut self, period: usize, order: usize) {
+        self.inner = std::mem::take(&mut self.inner).fourier(period, order);
+    }
+
+    /// Add dummy seasonal encoding.
+    #[wasm_bindgen(js_name = dummySeasonal)]
+    pub fn dummy_seasonal(&mut self, period: usize) {
+        self.inner = std::mem::take(&mut self.inner).dummy_seasonal(period);
+    }
+
+    // ── Changepoint features ─────────────────────────────────────
+
+    /// Add step-function changepoint indicators at the given indices.
+    #[wasm_bindgen(js_name = withChangepointSteps)]
+    pub fn with_changepoint_steps(&mut self, indices: Vec<usize>) {
+        self.inner = std::mem::take(&mut self.inner).with_changepoint_steps(indices);
+    }
+
+    /// Add changepoint features with a specific encoding.
+    ///
+    /// `encoding` ∈ "stepFunctions" | "regimeIndex" | "cumulativeCount"
+    #[wasm_bindgen(js_name = withChangepoints)]
+    pub fn with_changepoints(
+        &mut self,
+        indices: Vec<usize>,
+        encoding: &str,
+    ) -> Result<(), JsError> {
+        let enc = parse_changepoint_encoding(encoding)?;
+        let feat = Arc::new(InnerChangepointFeature::new(indices, enc));
+        self.inner = std::mem::take(&mut self.inner).with_structural(feat);
+        Ok(())
+    }
+
+    // ── Rolling / recursive features ─────────────────────────────
+
+    /// Add a rolling statistic with default lag = 1.
+    ///
+    /// `kind` ∈ "mean" | "std" | "var" | "min" | "max" | "median" | "sum" |
+    ///          "ewmMean" | "ewmStd" (EWM kinds require `alpha`)
+    #[wasm_bindgen(js_name = withRolling)]
+    pub fn with_rolling(
+        &mut self,
+        window: usize,
+        kind: &str,
+        alpha: Option<f64>,
+    ) -> Result<(), JsError> {
+        let k = parse_rolling_kind(kind, alpha)?;
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling(window, k)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    /// Add a rolling statistic with an explicit lag (≥ 1).
+    #[wasm_bindgen(js_name = withRollingLagged)]
+    pub fn with_rolling_lagged(
+        &mut self,
+        window: usize,
+        lag: usize,
+        kind: &str,
+        alpha: Option<f64>,
+    ) -> Result<(), JsError> {
+        let k = parse_rolling_kind(kind, alpha)?;
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_lagged(window, lag, k)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingMean)]
+    pub fn with_rolling_mean(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_mean(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingStd)]
+    pub fn with_rolling_std(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_std(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingVar)]
+    pub fn with_rolling_var(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_var(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingMin)]
+    pub fn with_rolling_min(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_min(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingMax)]
+    pub fn with_rolling_max(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_max(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingMedian)]
+    pub fn with_rolling_median(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_median(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withRollingSum)]
+    pub fn with_rolling_sum(&mut self, window: usize) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_rolling_sum(window)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withEwmMean)]
+    pub fn with_ewm_mean(&mut self, window: usize, alpha: f64) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_ewm_mean(window, alpha)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = withEwmStd)]
+    pub fn with_ewm_std(&mut self, window: usize, alpha: f64) -> Result<(), JsError> {
+        self.inner = std::mem::take(&mut self.inner)
+            .with_ewm_std(window, alpha)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    // ── Differencing ─────────────────────────────────────────────
+
+    /// Apply regular differencing of order `d` before fitting.
+    pub fn differencing(&mut self, d: usize) {
+        self.inner = std::mem::take(&mut self.inner).differencing(d);
+    }
+
+    /// Apply seasonal differencing.
+    #[wasm_bindgen(js_name = seasonalDifferencing)]
+    pub fn seasonal_differencing(&mut self, d: usize, period: usize) {
+        self.inner = std::mem::take(&mut self.inner).seasonal_differencing(d, period);
+    }
+
+    /// Apply fractional differencing of order `d` ∈ (0, 1).
+    #[wasm_bindgen(js_name = fractionalDifferencing)]
+    pub fn fractional_differencing(&mut self, d: f64) {
+        self.inner = std::mem::take(&mut self.inner).fractional_differencing(d);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RegressionForecaster wrapper
+// ---------------------------------------------------------------------------
+
+/// Multi-backend regression forecaster.
+///
+/// Supported backends (constructor arg): `"ols"` (default), `"ridge"`,
+/// `"elasticNet"`, `"quantile"`, `"wls"`, `"rls"`, `"tweedie"`, `"poisson"`,
+/// `"bls"`.
+///
+/// ```javascript
+/// const features = new RegressionFeatures();
+/// features.noTrend();
+/// features.lags(3);
+/// features.withRollingMean(7);
+///
+/// const model = RegressionForecaster.ols(features);
+/// model.fit(ts);
+/// const forecast = model.predict(12);
+/// ```
+#[wasm_bindgen]
+pub struct RegressionForecaster {
+    inner: InnerRegressionForecaster,
+}
+
+#[wasm_bindgen]
+impl RegressionForecaster {
+    /// Create an OLS regression forecaster with the given features.
+    pub fn ols(features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(InnerRegressionBackend::Ols, features.inner),
+        }
+    }
+
+    /// Create a Ridge regression forecaster (L2 regularization).
+    pub fn ridge(lambda: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Ridge { lambda },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create an ElasticNet regression forecaster (L1+L2 regularization).
+    #[wasm_bindgen(js_name = elasticNet)]
+    pub fn elastic_net(lambda: f64, alpha: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::ElasticNet { lambda, alpha },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create a Quantile regression forecaster (τ ∈ (0, 1)).
+    pub fn quantile(tau: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Quantile { tau },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create a Weighted Least Squares forecaster with exponential-decay weights.
+    #[wasm_bindgen(js_name = wlsDecay)]
+    pub fn wls_decay(decay: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Wls {
+                    strategy: InnerWeightStrategy::ExponentialDecay(decay),
+                },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create a Recursive Least Squares forecaster with a forgetting factor.
+    pub fn rls(forgetting_factor: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Rls { forgetting_factor },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create a Tweedie GLM forecaster.
+    pub fn tweedie(var_power: f64, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Tweedie {
+                    var_power,
+                    link_power: None,
+                },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Create a Poisson regression forecaster (count data).
+    pub fn poisson(features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(InnerRegressionBackend::Poisson, features.inner),
+        }
+    }
+
+    /// Create a Box-constrained least-squares forecaster.
+    ///
+    /// Pass `None` for either bound to leave it unconstrained.
+    pub fn bls(lower: Option<f64>, upper: Option<f64>, features: RegressionFeatures) -> Self {
+        Self {
+            inner: InnerRegressionForecaster::new(
+                InnerRegressionBackend::Bls { lower, upper },
+                features.inner,
+            ),
+        }
+    }
+
+    /// Fit the model on the supplied time series.
+    pub fn fit(&mut self, series: &TimeSeries) -> Result<(), JsError> {
+        self.inner
+            .fit(series.inner())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Generate forecasts for `horizon` steps.
+    pub fn predict(&self, horizon: usize) -> Result<Forecast, JsError> {
+        self.inner
+            .predict(horizon)
+            .map(Forecast::from_inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Forecast with confidence intervals.
+    #[wasm_bindgen(js_name = predictWithIntervals)]
+    pub fn predict_with_intervals(&self, horizon: usize, level: f64) -> Result<Forecast, JsError> {
+        self.inner
+            .predict_with_intervals(horizon, level)
+            .map(Forecast::from_inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+}
+
+// Silence unused import warnings for variants that are only accessed
+// indirectly through builder methods.
+#[allow(dead_code)]
+type _Unused = (InnerSeasonalSpec,);

--- a/src/transform/pipeline.rs
+++ b/src/transform/pipeline.rs
@@ -112,6 +112,13 @@ impl PipelineBuilder {
         self
     }
 
+    /// Append a pre-boxed transform — convenience for FFI / dynamic
+    /// construction where the concrete type isn't statically known.
+    pub fn transform_boxed(mut self, t: Box<dyn Transform>) -> Self {
+        self.transforms.push(t);
+        self
+    }
+
     /// Set the inner forecasting model.
     pub fn model(mut self, model: BoxedForecaster) -> Self {
         self.model = Some(model);


### PR DESCRIPTION
## Summary

Brings the npm package on par with the Rust crate for v0.6.0. Adds 7 new WASM binding files and extends 4 existing ones. Bumps the JS crate (`Cargo.toml`) from `0.5.1` → `0.6.0` and the npm `package.json` from `0.4.5` → `0.6.0` to match `anofox-forecast 0.6.0`.

## New binding files

| File | Surface |
|---|---|
| `regression.rs` | `RegressionForecaster` with 9 backends (OLS, Ridge, ElasticNet, Quantile, WLS, RLS, Tweedie, Poisson, BLS) + `RegressionFeatures` builder (trend, lags, Fourier, dummy seasonal, changepoints, **rolling statistics**, **EWM**, differencing, seasonal diff, fractional diff). This is the v0.6.0 theme — rolling features are recomputed per horizon step just like in the Rust path. |
| `pipeline.rs` | `Pipeline` + `PipelineBuilder` exposing the composable transform chain (BoxCox auto/fixed, Difference, SeasonalDifference, Standardize, Normalize, RobustScale, Log) with terminal builders for 12 inner model types. Adds one tiny internal method to the Rust crate (`PipelineBuilder::transform_boxed`) to support pre-boxed transforms from the FFI layer. |
| `hierarchy.rs` | `HierarchyTree` + all 7 reconciliation methods (BottomUp, TopDown, MiddleOut, MinTraceOls, MinTraceShrink, MinTraceVariance, MinTraceStruct) with JSON-friendly edge / forecast / residual ingestion. |
| `detection.rs` | `detectOutliers`, `detectOutliersAuto` (IQR / Z / Modified Z), `welchPeriodogram`, `detectDominantPeriod`. |
| `filters.rs` | `hpFilter` (Hodrick-Prescott), `cfFilter` (Christiano-Fitzgerald), `bkFilter` (Baxter-King), `hamiltonFilter`, `fractionalDifference`, `findMinFractionalD`. |
| `diagnostics.rs` | `analyzeDemand` (AID: distribution fitting + demand type + per-observation anomaly labels), `intermittentDiagnostics` (Syntetos-Boylan classification + recommended model). |

## Extended bindings

- **`features.rs`** — added **54 tsfresh-style feature wrappers** across basic (14), distribution (6), entropy (4), complexity (4), counting (15), change (6), autocorrelation (2), trend/AR (4). Was 8 functions → now ~62.
- **`global_models.rs`** — added `globalTheta` (completes the Global* family).
- **`cross_validation.rs`** — added `rollingForecast` (walk-forward evaluation).
- **`postprocess.rs`** — added `JsBinnedConformalPredictor`, `JsQRAPredictor`, `JsIDRPredictor`.

## Already in JS (not touched)

Forecasting models — all ARIMA/SARIMA/AutoARIMA, ETS/AutoETS, Theta variants, TBATS, GARCH, VAR, Kalman, Ensemble, intermittent, and baseline families already exist in `forecaster.rs`. Auto-selection (`AutoForecaster`, `AutoEnsembleForecaster`), decomposition (STL/MSTL), changepoint (PELT + CROPS), monitor (v0.6.0), basic validation (Ljung-Box, DW, JB, ADF, KPSS), and most of `postprocess.rs` were already present.

## Deferred to 0.6.1

- `Explainable` trait exposed per-model (requires per-model `explain()` wrappers — mechanical but voluminous).
- Standalone trend components (`PolynomialTrend`, `ExponentialTrend`, etc.) — already accessible via `RegressionFeatures.withTrendComponent()`.
- `DummySeasonality`, `FourierSeasonality` as standalone classes — already accessible via `RegressionFeatures` builder.

## Test plan

- [x] `cargo build -p anofox-forecast-js --target wasm32-unknown-unknown` — clean
- [x] `cargo test --lib --all-features` — **2717 passed, 0 failed**
- [x] `cargo clippy --lib --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual npm publish via `workflow_dispatch` after merge (the workflow's `release` trigger is tied to the already-existing v0.6.0 tag; we'll dispatch it manually once the fix for the `ENEEDAUTH` issue is in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)