### PR TITLE
Fix fingerprint significance: rank-based → 3σ parametric (#74)

### DIFF
--- a/src/forecastability/fingerprint.rs
+++ b/src/forecastability/fingerprint.rs
@@ -11,13 +11,14 @@ use super::surrogates::significance_bands;
 /// Compact forecastability fingerprint.
 #[derive(Debug, Clone)]
 pub struct ForecastabilityFingerprint {
-    /// Sum of AMI values at lags where AMI exceeds the surrogate upper band.
-    /// Higher = more total predictive signal.
+    /// Mean AMI across lags where AMI exceeds the 3σ threshold.
+    /// Normalized by `max_lag` so values are comparable across different
+    /// lag settings. Range: typically 0–5 (0 = no signal).
     pub information_mass: f64,
-    /// Last lag where AMI exceeds the surrogate upper band.
+    /// Last lag where AMI exceeds the 3σ threshold.
     /// Higher = deeper temporal dependence.
     pub information_horizon: usize,
-    /// Entropy of the significant AMI profile (normalized).
+    /// Entropy of the significant AMI profile (normalized to [0, 1]).
     /// Higher = more evenly distributed dependence across lags.
     pub information_structure: f64,
     /// `1 − (sum of significant GCMI) / (sum of significant AMI)`.
@@ -26,19 +27,21 @@ pub struct ForecastabilityFingerprint {
     /// Peak AMI / mean surrogate AMI at the same lag.
     /// Higher = stronger signal relative to noise.
     pub signal_to_noise: f64,
-    /// `AMI(1) / information_mass` — how concentrated the dependence is at
-    /// the first lag vs spread across all lags.
+    /// `AMI(1) / total_significant_ami` — how concentrated the dependence
+    /// is at the first lag vs spread across all lags.
     pub directness_ratio: f64,
-    /// Which lag indices (1-based) have AMI exceeding the surrogate band.
+    /// Which lag indices (1-based) have AMI exceeding the 3σ threshold.
     pub informative_horizons: Vec<usize>,
     /// The raw AMI curve.
     pub ami: Vec<f64>,
     /// The raw GCMI curve.
     pub gcmi: Vec<f64>,
-    /// Surrogate upper band for AMI.
-    pub surrogate_upper: Vec<f64>,
+    /// Surrogate 3σ threshold for AMI (`mean + 3 * std`).
+    pub surrogate_threshold: Vec<f64>,
     /// Surrogate mean for AMI.
     pub surrogate_mean: Vec<f64>,
+    /// Surrogate std for AMI.
+    pub surrogate_std: Vec<f64>,
 }
 
 impl ForecastabilityFingerprint {
@@ -64,23 +67,31 @@ impl ForecastabilityFingerprint {
         // Compute surrogate significance bands for AMI.
         let bands = significance_bands(series, ami_curve, max_lag, n_surrogates, alpha, seed);
 
-        // Identify informative horizons: where AMI > surrogate upper band.
+        // Identify informative horizons: where AMI > 3σ threshold.
+        // The 3σ parametric test (mean + 3*std) is more selective than the
+        // rank-based percentile upper band, matching the Python original.
         let informative_horizons: Vec<usize> = (0..max_lag)
-            .filter(|&i| ami[i] > bands.upper[i])
+            .filter(|&i| ami[i] > bands.threshold_3sigma[i])
             .map(|i| i + 1) // 1-based
             .collect();
 
-        // Information mass: sum of significant AMI.
-        let information_mass: f64 = informative_horizons.iter().map(|&h| ami[h - 1]).sum();
+        // Information mass: mean significant AMI, normalized by max_lag.
+        // This makes the value comparable across different max_lag settings.
+        let total_significant_ami: f64 = informative_horizons.iter().map(|&h| ami[h - 1]).sum();
+        let information_mass = if max_lag > 0 {
+            total_significant_ami / max_lag as f64
+        } else {
+            0.0
+        };
 
         // Information horizon: last significant lag.
         let information_horizon = informative_horizons.last().copied().unwrap_or(0);
 
         // Information structure: entropy of significant AMI profile.
-        let information_structure = if information_mass > 1e-15 {
+        let information_structure = if total_significant_ami > 1e-15 {
             let probs: Vec<f64> = informative_horizons
                 .iter()
-                .map(|&h| ami[h - 1] / information_mass)
+                .map(|&h| ami[h - 1] / total_significant_ami)
                 .collect();
             let k = probs.len() as f64;
             if k <= 1.0 {
@@ -102,8 +113,8 @@ impl ForecastabilityFingerprint {
             .iter()
             .map(|&h| gcmi[h - 1].max(0.0))
             .sum();
-        let nonlinear_share = if information_mass > 1e-15 {
-            (1.0 - gcmi_mass / information_mass).clamp(0.0, 1.0)
+        let nonlinear_share = if total_significant_ami > 1e-15 {
+            (1.0 - gcmi_mass / total_significant_ami).clamp(0.0, 1.0)
         } else {
             0.0
         };
@@ -118,8 +129,8 @@ impl ForecastabilityFingerprint {
         let signal_to_noise = peak_ami / surr_mean_at_peak;
 
         // Directness ratio.
-        let directness_ratio = if information_mass > 1e-15 {
-            ami[0] / information_mass
+        let directness_ratio = if total_significant_ami > 1e-15 {
+            ami[0] / total_significant_ami
         } else {
             0.0
         };
@@ -134,8 +145,9 @@ impl ForecastabilityFingerprint {
             informative_horizons,
             ami,
             gcmi,
-            surrogate_upper: bands.upper,
+            surrogate_threshold: bands.threshold_3sigma,
             surrogate_mean: bands.mean,
+            surrogate_std: bands.std,
         }
     }
 }

--- a/src/forecastability/surrogates.rs
+++ b/src/forecastability/surrogates.rs
@@ -92,6 +92,13 @@ pub struct SignificanceBands {
     pub upper: Vec<f64>,
     /// Mean of the surrogate distribution at each lag.
     pub mean: Vec<f64>,
+    /// Standard deviation of the surrogate distribution at each lag.
+    pub std: Vec<f64>,
+    /// 3σ threshold: `mean + 3 * std` at each lag. This is the recommended
+    /// significance threshold (matches the Python `dependence-forecastability`
+    /// parametric test). More selective than the rank-based percentile upper
+    /// band, especially with few surrogates.
+    pub threshold_3sigma: Vec<f64>,
     /// Number of surrogates used.
     pub n_surrogates: usize,
     /// Significance level used.
@@ -176,12 +183,16 @@ where
     let mut lower = Vec::with_capacity(max_lag);
     let mut upper = Vec::with_capacity(max_lag);
     let mut mean = Vec::with_capacity(max_lag);
+    let mut std = Vec::with_capacity(max_lag);
+    let mut threshold_3sigma = Vec::with_capacity(max_lag);
 
     for vals in &mut lag_values {
         if vals.is_empty() {
             lower.push(0.0);
             upper.push(0.0);
             mean.push(0.0);
+            std.push(0.0);
+            threshold_3sigma.push(0.0);
             continue;
         }
         vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -190,13 +201,23 @@ where
         let hi_idx = ((hi_q * n as f64) as usize).min(n - 1);
         lower.push(vals[lo_idx]);
         upper.push(vals[hi_idx]);
-        mean.push(vals.iter().sum::<f64>() / n as f64);
+        let m = vals.iter().sum::<f64>() / n as f64;
+        let s = if n > 1 {
+            (vals.iter().map(|&v| (v - m) * (v - m)).sum::<f64>() / (n - 1) as f64).sqrt()
+        } else {
+            0.0
+        };
+        mean.push(m);
+        std.push(s);
+        threshold_3sigma.push(m + 3.0 * s);
     }
 
     SignificanceBands {
         lower,
         upper,
         mean,
+        std,
+        threshold_3sigma,
         n_surrogates,
         alpha,
     }

--- a/tests/forecastability_validation.rs
+++ b/tests/forecastability_validation.rs
@@ -366,8 +366,8 @@ fn fingerprint_ar1_linear_process_correctly_not_significant() {
 
     // AR(1) is a purely linear process. Phase surrogates preserve the power
     // spectrum (and hence the autocorrelation structure), so the surrogate
-    // AMI values match the original. The significance test correctly reports
-    // NO nonlinear structure beyond what the power spectrum explains.
+    // AMI values match the original. With the 3σ threshold (mean + 3*std),
+    // very few or no lags should be flagged as significant.
     let series = make_ar1(1000, 0.9, 42);
     let fp = ForecastabilityFingerprint::compute(&series, 10, 50, 0.05, Some(1));
 
@@ -376,6 +376,13 @@ fn fingerprint_ar1_linear_process_correctly_not_significant() {
         fp.signal_to_noise < 2.0,
         "AR(1) SNR should be ~1.0 (linear process, surrogates match), got {}",
         fp.signal_to_noise
+    );
+
+    // With 3σ threshold, information_mass should be low (normalized by max_lag).
+    assert!(
+        fp.information_mass < 0.5,
+        "AR(1) normalized information_mass should be small with 3σ test, got {}",
+        fp.information_mass
     );
 
     // The raw AMI curve should still be positive and decaying.


### PR DESCRIPTION
Fixes #74

## Changes
1. **3σ parametric threshold** (`mean + 3*std`) instead of rank-based max — matches the Python `dependence-forecastability` original. Much more selective with few surrogates.
2. **`std` + `threshold_3sigma`** added to `SignificanceBands`
3. **Normalized `information_mass`** — divided by `max_lag` so values are comparable across settings
4. Updated struct fields: `surrogate_upper` → `surrogate_threshold`, added `surrogate_std`

## Test plan
- [x] 36 lib tests pass
- [x] 19 validation tests pass (updated AR(1) fingerprint test for new 3σ behavior)
- [x] 2753 total tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)