### PR TITLE
Add CQR, EnbPI, ACI conformal prediction methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Three new conformal prediction methods** (in `postprocess::`, behind the `postprocess` feature):
+  - **CQR** (`CqrPredictor`, `CqrResult`) — Conformalized Quantile Regression (Romano, Patterson & Candès, NeurIPS 2019). Wraps any quantile-regression base learner; conformity score `E_i = max(q_lo - y, y - q_hi)` adjusts the bounds symmetrically. Tighter than absolute-residual conformal under heteroscedasticity.
+  - **EnbPI** (`EnbPiPredictor`, `EnbPiResult`) — Ensemble Bootstrap Prediction Interval (Xu & Xie, ICML 2021). Leave-one-out residuals from a bagged ensemble (no retraining required). Online residual window via `update()` for distribution drift.
+  - **ACI** (`AciPredictor`) — Adaptive Conformal Inference (Gibbs & Candès, NeurIPS 2021). Stateful streaming wrapper that adjusts α_t each step from coverage error: `α_{t+1} = α_t + γ(α_target - err_t)`. Long-run coverage converges to target under arbitrary distribution drift.
+- 22 new tests covering all three predictors, including a stationary-noise CQR coverage test and a drift-response ACI test.
+
 ## [0.7.2] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-05-05
+
 ### Added
 
 - **Three new conformal prediction methods** (in `postprocess::`, behind the `postprocess` feature):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ console.log(forecast.values);
   - Conformal Prediction: Distribution-free intervals with coverage guarantees
   - Per-horizon-step conformal: separate interval widths per forecast step (tighter at h=1, wider at h=12)
   - Binned Conformal Prediction: Heteroscedastic intervals — bins residuals by predicted magnitude for wider intervals where uncertainty is larger
+  - **CQR** (Conformalized Quantile Regression): wraps any quantile-regression base learner with symmetric bound adjustment — tighter than absolute-residual conformal under heteroscedasticity (Romano, Patterson & Candès, NeurIPS 2019)
+  - **EnbPI** (Ensemble Bootstrap Prediction Interval): leave-one-out residuals from a bagged ensemble (no retraining); online window for drift (Xu & Xie, ICML 2021)
+  - **ACI** (Adaptive Conformal Inference): stateful streaming wrapper with α-adaptation — long-run coverage converges to target under arbitrary distribution drift (Gibbs & Candès, NeurIPS 2021)
   - Bootstrap Prediction Intervals: Model-agnostic residual resampling with cumulative error paths (IID and block bootstrap)
   - Historical Simulation: Non-parametric empirical error distribution
   - Normal Predictor: Gaussian error assumption baseline
@@ -253,7 +256,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.7.2"
+anofox-forecast = "0.7.3"
 ```
 
 ### Optional Features
@@ -746,6 +749,9 @@ println!("Upper: {:?}", intervals.upper());
 | `PostProcessor` | Unified API for all postprocessing methods |
 | `ConformalPredictor` | Distribution-free prediction intervals |
 | `BinnedConformalPredictor` | Heteroscedastic intervals — bins by predicted magnitude |
+| `CqrPredictor` / `CqrResult` | Conformalized Quantile Regression — wraps quantile base learners |
+| `EnbPiPredictor` / `EnbPiResult` | Ensemble Bootstrap Prediction Interval — bagged LOO residuals with online window |
+| `AciPredictor` | Adaptive Conformal Inference — streaming α-adaptation under drift |
 | `HistoricalSimulator` | Empirical error distribution |
 | `IDRPredictor` | Isotonic Distributional Regression |
 | `QRAPredictor` | Quantile Regression Averaging |

--- a/src/postprocess/aci.rs
+++ b/src/postprocess/aci.rs
@@ -1,0 +1,375 @@
+//! Adaptive Conformal Inference (ACI).
+//!
+//! Gibbs, I., & Candès, E. J. (2021).
+//! *Adaptive Conformal Inference under Distribution Shift.*
+//! NeurIPS 2021.
+//!
+//! ACI maintains an online estimate of the working coverage level α_t and
+//! adjusts it each step based on whether the most recent observation fell
+//! inside the predicted interval:
+//!
+//! ```text
+//! err_t = 1 if y_t ∉ C_t(x_t),  0 otherwise
+//! α_{t+1} = α_t + γ * (α_target - err_t)
+//! ```
+//!
+//! where γ > 0 is the learning rate. The interval radius is recomputed
+//! each step from the (1 - α_t) quantile of recent absolute residuals.
+//!
+//! Under arbitrary distribution drift, ACI guarantees that the long-run
+//! empirical miscoverage rate converges to the target α — without any
+//! distributional assumptions.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! let mut aci = AciPredictor::new(0.90, 0.01);   // target coverage 90%, γ=0.01
+//! aci.fit(&initial_residuals)?;                  // seed the residual buffer
+//! for (forecast, actual) in stream {
+//!     let (lo, hi) = aci.predict_interval(forecast);
+//!     aci.observe(forecast, actual);             // updates α_t and residuals
+//! }
+//! ```
+
+use crate::error::{ForecastError, Result};
+use crate::postprocess::PredictionIntervals;
+
+/// Adaptive Conformal Inference predictor.
+///
+/// Stateful, online: the predictor tracks a sliding window of recent
+/// absolute residuals and an online α_t that is updated after each
+/// `observe()` call.
+#[derive(Debug, Clone)]
+pub struct AciPredictor {
+    /// Target miscoverage rate α_target = 1 - target_coverage.
+    alpha_target: f64,
+    /// Learning rate for the α update.
+    gamma: f64,
+    /// Current online miscoverage rate α_t.
+    alpha_t: f64,
+    /// Maximum number of residuals to retain in the sliding window.
+    max_window: usize,
+    /// Buffer of recent absolute residuals (unsorted; sorted on demand).
+    residuals: Vec<f64>,
+    /// Number of `observe()` calls processed.
+    n_observed: usize,
+    /// Number of times the actual fell outside the interval.
+    n_misses: usize,
+}
+
+impl AciPredictor {
+    /// Create a new ACI predictor.
+    ///
+    /// # Arguments
+    /// * `target_coverage` — desired long-run coverage (e.g. 0.90)
+    /// * `gamma` — learning rate; typical values 0.005–0.05. Larger γ reacts
+    ///   faster to drift but causes wider intervals.
+    ///
+    /// # Panics
+    /// Panics if `target_coverage ∉ (0, 1)` or `gamma ≤ 0`.
+    pub fn new(target_coverage: f64, gamma: f64) -> Self {
+        assert!(
+            target_coverage > 0.0 && target_coverage < 1.0,
+            "target_coverage must be in (0, 1)"
+        );
+        assert!(gamma > 0.0, "gamma must be > 0");
+        let alpha = 1.0 - target_coverage;
+        Self {
+            alpha_target: alpha,
+            gamma,
+            alpha_t: alpha,
+            max_window: 500,
+            residuals: Vec::new(),
+            n_observed: 0,
+            n_misses: 0,
+        }
+    }
+
+    /// Set the maximum residual window size (default 500). Smaller windows
+    /// adapt faster to drift; larger windows produce smoother intervals.
+    pub fn with_max_window(mut self, max_window: usize) -> Self {
+        assert!(max_window > 0, "max_window must be > 0");
+        self.max_window = max_window;
+        self
+    }
+
+    /// Target coverage level.
+    pub fn target_coverage(&self) -> f64 {
+        1.0 - self.alpha_target
+    }
+
+    /// Current online α_t (the working miscoverage level).
+    pub fn alpha_t(&self) -> f64 {
+        self.alpha_t
+    }
+
+    /// Learning rate γ.
+    pub fn gamma(&self) -> f64 {
+        self.gamma
+    }
+
+    /// Number of observations processed via `observe()`.
+    pub fn n_observed(&self) -> usize {
+        self.n_observed
+    }
+
+    /// Empirical miscoverage rate over all `observe()` calls so far.
+    pub fn empirical_miscoverage(&self) -> f64 {
+        if self.n_observed == 0 {
+            0.0
+        } else {
+            self.n_misses as f64 / self.n_observed as f64
+        }
+    }
+
+    /// Seed the residual buffer with prior absolute residuals.
+    ///
+    /// Required at least once before `predict_interval()` will return
+    /// non-trivial bounds. The most recent `max_window` residuals are kept.
+    pub fn fit(&mut self, abs_residuals: &[f64]) -> Result<()> {
+        if abs_residuals.is_empty() {
+            return Err(ForecastError::EmptyData);
+        }
+        for &r in abs_residuals {
+            if !r.is_finite() {
+                return Err(ForecastError::InvalidParameter(
+                    "residuals must be finite".to_string(),
+                ));
+            }
+        }
+        let start = abs_residuals.len().saturating_sub(self.max_window);
+        self.residuals = abs_residuals[start..].to_vec();
+        Ok(())
+    }
+
+    /// Compute the current interval radius from the residual buffer at level
+    /// (1 - α_t). Returns 0.0 if the buffer is empty.
+    pub fn current_radius(&self) -> f64 {
+        if self.residuals.is_empty() {
+            return 0.0;
+        }
+        let mut sorted = self.residuals.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n = sorted.len();
+        // α_t is clamped to (0, 1) in observe(), so coverage is in (0, 1).
+        let coverage = 1.0 - self.alpha_t;
+        let level = (coverage * (n as f64 + 1.0) / n as f64).min(1.0);
+        let idx = ((n as f64) * level).ceil() as usize;
+        let idx = idx.saturating_sub(1).min(n - 1);
+        sorted[idx]
+    }
+
+    /// Produce an interval `[forecast - r, forecast + r]` using the current
+    /// radius `r` derived from α_t.
+    pub fn predict_interval(&self, forecast: f64) -> (f64, f64) {
+        let r = self.current_radius();
+        (forecast - r, forecast + r)
+    }
+
+    /// Produce intervals for a slice of forecasts.
+    pub fn predict_intervals(&self, forecasts: &[f64]) -> Result<PredictionIntervals> {
+        let r = self.current_radius();
+        let lower: Vec<f64> = forecasts.iter().map(|&f| f - r).collect();
+        let upper: Vec<f64> = forecasts.iter().map(|&f| f + r).collect();
+        PredictionIntervals::from_bounds(lower, upper, 1.0 - self.alpha_target)
+    }
+
+    /// Observe a (forecast, actual) pair and update α_t + the residual
+    /// buffer.
+    pub fn observe(&mut self, forecast: f64, actual: f64) {
+        let radius = self.current_radius();
+        let lower = forecast - radius;
+        let upper = forecast + radius;
+        let inside = actual >= lower && actual <= upper;
+        let err: f64 = if inside { 0.0 } else { 1.0 };
+
+        // ACI update: α_{t+1} = α_t + γ (α_target - err_t).
+        // Note: when the actual is INSIDE (err=0), this pushes α_t up
+        // (target=0.10 - 0 = +0.10), widening intervals to be more
+        // conservative? No — wait: alpha is miscoverage. err=0 means
+        // covered. We want α_t to *decrease* (less miscoverage budget) when
+        // covered. The standard ACI formulation is:
+        //   α_{t+1} = α_t + γ (α_target - err_t)
+        // err=0 (covered): α_t increases by γ * α_target (e.g. +0.001 with
+        //   α_target=0.10, γ=0.01). This gives BACK miscoverage budget,
+        //   tightening intervals slightly.
+        // err=1 (missed): α_t increases by γ * (α_target - 1) (e.g. -0.009),
+        //   pulling α_t DOWN, widening intervals.
+        // This matches Gibbs & Candès Algorithm 1.
+        self.alpha_t += self.gamma * (self.alpha_target - err);
+        // Clamp α_t to (0, 1) — the working coverage 1-α_t must be a valid
+        // probability. Recommended in the original Gibbs & Candès paper to
+        // avoid the radius oscillating between 0 (α_t ≥ 1) and the max
+        // residual (α_t ≤ 0).
+        self.alpha_t = self.alpha_t.clamp(0.001, 0.999);
+
+        // Append the new absolute residual and slide the window.
+        let abs_err = (forecast - actual).abs();
+        self.residuals.push(abs_err);
+        if self.residuals.len() > self.max_window {
+            let drop = self.residuals.len() - self.max_window;
+            self.residuals.drain(..drop);
+        }
+
+        self.n_observed += 1;
+        if !inside {
+            self.n_misses += 1;
+        }
+    }
+
+    /// Reset the online state (α_t back to α_target, miss counter to 0)
+    /// without clearing the residual buffer.
+    pub fn reset_alpha(&mut self) {
+        self.alpha_t = self.alpha_target;
+        self.n_observed = 0;
+        self.n_misses = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    #[test]
+    fn fit_seeds_residual_buffer() {
+        let mut aci = AciPredictor::new(0.90, 0.01);
+        aci.fit(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        // Radius is the (1-α_t) quantile of {1,2,3,4,5} ≈ 5
+        let r = aci.current_radius();
+        assert!(r >= 4.0 && r <= 5.0);
+    }
+
+    #[test]
+    fn fit_empty_errors() {
+        let mut aci = AciPredictor::new(0.90, 0.01);
+        let err = aci.fit(&[]).unwrap_err();
+        assert!(matches!(err, ForecastError::EmptyData));
+    }
+
+    #[test]
+    fn predict_interval_uses_current_radius() {
+        let mut aci = AciPredictor::new(0.90, 0.01);
+        aci.fit(&[0.5; 50]).unwrap();
+        let (lo, hi) = aci.predict_interval(10.0);
+        assert!((lo - 9.5).abs() < 1e-9);
+        assert!((hi - 10.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn observe_inside_increases_alpha_t() {
+        let mut aci = AciPredictor::new(0.90, 0.05);
+        aci.fit(&[1.0; 30]).unwrap();
+        let alpha_before = aci.alpha_t();
+        // Forecast 0, actual 0 → inside → err=0 → α_t += γ * α_target
+        aci.observe(0.0, 0.0);
+        assert!(
+            aci.alpha_t() > alpha_before,
+            "covered observation should push α_t UP, but {} <= {}",
+            aci.alpha_t(),
+            alpha_before
+        );
+    }
+
+    #[test]
+    fn observe_outside_decreases_alpha_t() {
+        let mut aci = AciPredictor::new(0.90, 0.05);
+        aci.fit(&[0.1; 30]).unwrap();
+        let alpha_before = aci.alpha_t();
+        // Forecast 0, actual 1000 (well outside any reasonable interval)
+        aci.observe(0.0, 1000.0);
+        assert!(
+            aci.alpha_t() < alpha_before,
+            "missed observation should push α_t DOWN, but {} >= {}",
+            aci.alpha_t(),
+            alpha_before
+        );
+    }
+
+    #[test]
+    fn long_run_coverage_approaches_target() {
+        // Stationary stream: forecast = 0, actual ~ N(0, 1).
+        let mut aci = AciPredictor::new(0.90, 0.02).with_max_window(200);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // Seed with some initial residuals
+        let init: Vec<f64> = (0..50).map(|_| rng.gen::<f64>() * 2.0).collect();
+        aci.fit(&init).unwrap();
+
+        // Run 2000 observations
+        for _ in 0..2000 {
+            // Standard-normal-ish via Box-Muller approximation
+            let u1: f64 = rng.gen::<f64>().max(1e-300);
+            let u2: f64 = rng.gen();
+            let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos();
+            aci.observe(0.0, z);
+        }
+
+        let cov = 1.0 - aci.empirical_miscoverage();
+        // Should converge near the 0.90 target — wide tolerance for finite n.
+        assert!(
+            (0.83..0.97).contains(&cov),
+            "long-run coverage should approach target 0.90, got {:.3}",
+            cov
+        );
+    }
+
+    #[test]
+    fn responds_to_drift() {
+        // Distribution shifts at t=500: residuals jump from ±0.5 to ±5.0.
+        let mut aci = AciPredictor::new(0.90, 0.05).with_max_window(100);
+        aci.fit(&[0.5; 50]).unwrap();
+
+        let radius_before_drift = aci.current_radius();
+
+        // First 500 obs: small residuals (model well-calibrated).
+        for i in 0..500 {
+            let actual = if i % 2 == 0 { 0.4 } else { -0.4 };
+            aci.observe(0.0, actual);
+        }
+
+        // Drift: observations now far from forecast.
+        for i in 0..500 {
+            let actual = if i % 2 == 0 { 5.0 } else { -5.0 };
+            aci.observe(0.0, actual);
+        }
+
+        let radius_after_drift = aci.current_radius();
+        assert!(
+            radius_after_drift > radius_before_drift,
+            "ACI should widen intervals after drift: before={:.3}, after={:.3}",
+            radius_before_drift,
+            radius_after_drift
+        );
+        // The radius should have grown substantially.
+        assert!(
+            radius_after_drift > 1.5,
+            "radius after drift should reflect new residual scale, got {:.3}",
+            radius_after_drift
+        );
+    }
+
+    #[test]
+    fn predict_intervals_returns_correct_coverage() {
+        let mut aci = AciPredictor::new(0.95, 0.01);
+        aci.fit(&[1.0; 100]).unwrap();
+        let intervals = aci.predict_intervals(&[10.0, 20.0, 30.0]).unwrap();
+        assert_eq!(intervals.coverage(), 0.95);
+        assert_eq!(intervals.len(), 3);
+    }
+
+    #[test]
+    fn reset_alpha_clears_counters_only() {
+        let mut aci = AciPredictor::new(0.90, 0.05);
+        aci.fit(&[1.0; 30]).unwrap();
+        aci.observe(0.0, 5.0); // miss
+        aci.observe(0.0, 0.5); // hit
+        assert_eq!(aci.n_observed(), 2);
+        aci.reset_alpha();
+        assert_eq!(aci.n_observed(), 0);
+        assert!((aci.alpha_t() - 0.10).abs() < 1e-12);
+        // Residuals should still be there (3 observations + 30 seed = 32)
+        assert!(!aci.residuals.is_empty());
+    }
+}

--- a/src/postprocess/cqr.rs
+++ b/src/postprocess/cqr.rs
@@ -1,0 +1,305 @@
+//! Conformalized Quantile Regression (CQR).
+//!
+//! Romano, Y., Patterson, E., & Candès, E. J. (2019).
+//! *Conformalized Quantile Regression.*
+//! Advances in Neural Information Processing Systems, 32.
+//!
+//! CQR wraps a quantile-regression base learner: rather than computing
+//! conformity scores from absolute residuals (as in standard split
+//! conformal), it scores against the gap between predicted quantile bounds
+//! and the actual value:
+//!
+//! ```text
+//! E_i = max(q_lo_i - y_i, y_i - q_hi_i)
+//! ```
+//!
+//! The (1-α)(n+1)/n quantile of these scores adjusts both bounds:
+//!
+//! ```text
+//! C(x) = [q_lo(x) - Q, q_hi(x) + Q]
+//! ```
+//!
+//! When the base quantile regressor is well-calibrated, `Q ≈ 0` and the
+//! intervals stay tight. When it under- or over-covers, `Q` corrects the
+//! gap. Tighter than absolute-residual conformal whenever heteroscedasticity
+//! exists in the residuals.
+
+use crate::error::{ForecastError, Result};
+use crate::postprocess::PredictionIntervals;
+
+/// Result of fitting a CQR predictor.
+#[derive(Debug, Clone)]
+pub struct CqrResult {
+    /// Sorted conformity scores (one per calibration point).
+    scores: Vec<f64>,
+    /// The (1-α)(n+1)/n quantile — used to widen / tighten interval bounds.
+    quantile_value: f64,
+    /// Target coverage level (1-α).
+    coverage: f64,
+    /// Lower quantile τ used by the base learner (typically α/2).
+    tau_lo: f64,
+    /// Upper quantile τ used by the base learner (typically 1 − α/2).
+    tau_hi: f64,
+}
+
+impl CqrResult {
+    /// Sorted conformity scores from the calibration set.
+    pub fn scores(&self) -> &[f64] {
+        &self.scores
+    }
+
+    /// Quantile adjustment Q applied symmetrically to both bounds.
+    pub fn quantile_value(&self) -> f64 {
+        self.quantile_value
+    }
+
+    pub fn coverage(&self) -> f64 {
+        self.coverage
+    }
+
+    pub fn tau_lo(&self) -> f64 {
+        self.tau_lo
+    }
+
+    pub fn tau_hi(&self) -> f64 {
+        self.tau_hi
+    }
+
+    /// Apply the calibration to new lower/upper quantile predictions.
+    ///
+    /// Returns conformalized intervals: `[q_lo - Q, q_hi + Q]`.
+    pub fn predict_intervals(&self, q_lo: &[f64], q_hi: &[f64]) -> Result<PredictionIntervals> {
+        if q_lo.len() != q_hi.len() {
+            return Err(ForecastError::DimensionMismatch {
+                expected: q_lo.len(),
+                got: q_hi.len(),
+            });
+        }
+        let lower: Vec<f64> = q_lo.iter().map(|&q| q - self.quantile_value).collect();
+        let upper: Vec<f64> = q_hi.iter().map(|&q| q + self.quantile_value).collect();
+        PredictionIntervals::from_bounds(lower, upper, self.coverage)
+    }
+}
+
+/// Conformalized Quantile Regression predictor.
+///
+/// Wraps any base learner that produces lower / upper quantile forecasts and
+/// recalibrates them to achieve nominal coverage.
+#[derive(Debug, Clone)]
+pub struct CqrPredictor {
+    coverage: f64,
+}
+
+impl CqrPredictor {
+    /// Create a CQR predictor targeting the given coverage level.
+    ///
+    /// # Panics
+    /// Panics if coverage is not in (0, 1).
+    pub fn new(coverage: f64) -> Self {
+        assert!(
+            coverage > 0.0 && coverage < 1.0,
+            "coverage must be in (0, 1)"
+        );
+        Self { coverage }
+    }
+
+    /// Target coverage level.
+    pub fn coverage(&self) -> f64 {
+        self.coverage
+    }
+
+    /// Lower base-learner quantile τ used in fitting (= α/2 by default).
+    pub fn tau_lo(&self) -> f64 {
+        (1.0 - self.coverage) / 2.0
+    }
+
+    /// Upper base-learner quantile τ used in fitting (= 1 - α/2 by default).
+    pub fn tau_hi(&self) -> f64 {
+        1.0 - (1.0 - self.coverage) / 2.0
+    }
+
+    /// Fit the CQR predictor on calibration quantile predictions and actuals.
+    ///
+    /// # Arguments
+    /// * `q_lo_calib` — lower quantile predictions on calibration set
+    /// * `q_hi_calib` — upper quantile predictions on calibration set
+    /// * `actuals` — actual values for the calibration set
+    pub fn fit(
+        &self,
+        q_lo_calib: &[f64],
+        q_hi_calib: &[f64],
+        actuals: &[f64],
+    ) -> Result<CqrResult> {
+        let n = actuals.len();
+        if n == 0 {
+            return Err(ForecastError::EmptyData);
+        }
+        if q_lo_calib.len() != n || q_hi_calib.len() != n {
+            return Err(ForecastError::DimensionMismatch {
+                expected: n,
+                got: q_lo_calib.len().min(q_hi_calib.len()),
+            });
+        }
+
+        // Conformity score: E_i = max(q_lo - y, y - q_hi).
+        // Positive E_i means the actual fell outside the [q_lo, q_hi] band.
+        let mut scores: Vec<f64> = (0..n)
+            .map(|i| (q_lo_calib[i] - actuals[i]).max(actuals[i] - q_hi_calib[i]))
+            .collect();
+        scores.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        // Take the (1-α)(n+1)/n empirical quantile.
+        // Equivalently: the ⌈(1-α)(n+1)⌉-th smallest score.
+        let level = self.coverage * (n as f64 + 1.0) / n as f64;
+        let level = level.min(1.0);
+        let idx = ((n as f64) * level).ceil() as usize;
+        let idx = idx.saturating_sub(1).min(n - 1);
+        let quantile_value = scores[idx];
+
+        Ok(CqrResult {
+            scores,
+            quantile_value,
+            coverage: self.coverage,
+            tau_lo: self.tau_lo(),
+            tau_hi: self.tau_hi(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Calibrated quantile forecasts: q_lo and q_hi already cover roughly
+    /// `coverage` of the actuals → CQR should report a near-zero adjustment.
+    #[test]
+    fn calibrated_base_gives_small_adjustment() {
+        let n = 200;
+        let actuals: Vec<f64> = (0..n).map(|i| (i as f64 * 0.1).sin()).collect();
+        // Symmetric well-calibrated bounds: ±0.5 around actuals.
+        let q_lo: Vec<f64> = actuals.iter().map(|&y| y - 0.5).collect();
+        let q_hi: Vec<f64> = actuals.iter().map(|&y| y + 0.5).collect();
+
+        let cqr = CqrPredictor::new(0.90);
+        let result = cqr.fit(&q_lo, &q_hi, &actuals).unwrap();
+
+        // Every actual is inside, so all conformity scores are ≤ 0
+        // → quantile_value ≤ 0 (bands can be tightened).
+        assert!(
+            result.quantile_value() <= 0.0,
+            "well-calibrated CQR should not need to widen, got Q={}",
+            result.quantile_value()
+        );
+    }
+
+    #[test]
+    fn under_covering_base_widens_intervals() {
+        // q_lo and q_hi are too tight: actuals fall outside the band.
+        let n = 200;
+        let actuals: Vec<f64> = (0..n).map(|i| (i as f64 * 0.1).sin()).collect();
+        let q_lo: Vec<f64> = actuals.iter().map(|&y| y - 0.05).collect();
+        let q_hi: Vec<f64> = actuals.iter().map(|&y| y + 0.05).collect();
+
+        // Inflate every other actual so the band misses it by 0.5
+        let mut shifted_actuals = actuals.clone();
+        for (i, a) in shifted_actuals.iter_mut().enumerate() {
+            if i % 2 == 0 {
+                *a += 0.6;
+            }
+        }
+
+        let cqr = CqrPredictor::new(0.90);
+        let result = cqr.fit(&q_lo, &q_hi, &shifted_actuals).unwrap();
+
+        // Adjustment must widen (positive) to cover the under-covered points.
+        assert!(
+            result.quantile_value() > 0.3,
+            "under-covering CQR should widen significantly, got Q={}",
+            result.quantile_value()
+        );
+    }
+
+    #[test]
+    fn predict_intervals_applies_symmetric_adjustment() {
+        let actuals = vec![0.0; 100];
+        let q_lo = vec![-1.0; 100];
+        let q_hi = vec![1.0; 100];
+
+        let cqr = CqrPredictor::new(0.80);
+        let result = cqr.fit(&q_lo, &q_hi, &actuals).unwrap();
+
+        // Apply to new test forecasts.
+        let test_lo = vec![5.0, 10.0];
+        let test_hi = vec![7.0, 12.0];
+        let intervals = result.predict_intervals(&test_lo, &test_hi).unwrap();
+
+        // The adjustment should be applied symmetrically.
+        let q = result.quantile_value();
+        assert!((intervals.lower()[0] - (5.0 - q)).abs() < 1e-12);
+        assert!((intervals.upper()[0] - (7.0 + q)).abs() < 1e-12);
+        assert_eq!(intervals.coverage(), 0.80);
+    }
+
+    #[test]
+    fn empty_calibration_errors() {
+        let cqr = CqrPredictor::new(0.90);
+        let err = cqr.fit(&[], &[], &[]).unwrap_err();
+        assert!(matches!(err, ForecastError::EmptyData));
+    }
+
+    #[test]
+    fn dimension_mismatch_errors() {
+        let cqr = CqrPredictor::new(0.90);
+        let err = cqr.fit(&[1.0, 2.0], &[3.0], &[4.0, 5.0]).unwrap_err();
+        assert!(matches!(err, ForecastError::DimensionMismatch { .. }));
+    }
+
+    #[test]
+    fn tau_lo_tau_hi_match_coverage() {
+        let cqr = CqrPredictor::new(0.90);
+        assert!((cqr.tau_lo() - 0.05).abs() < 1e-12);
+        assert!((cqr.tau_hi() - 0.95).abs() < 1e-12);
+    }
+
+    #[test]
+    fn coverage_actually_achieved_on_holdout() {
+        // Stationary synthetic experiment: same noise distribution on
+        // calibration and test — CQR's exchangeability assumption holds.
+        // The base learner under-covers (band too tight); CQR's
+        // adjustment widens it to nominal.
+        let n_per_set = 500;
+
+        // Same noise distribution everywhere — uniform U(-1, 1).
+        let synth = |n: usize, salt: u64| -> Vec<f64> {
+            (0..n)
+                .map(|i| {
+                    let h = (i as u64).wrapping_mul(2654435761).wrapping_add(salt);
+                    ((h % 1000) as f64 / 1000.0 - 0.5) * 2.0
+                })
+                .collect()
+        };
+        let eps_calib = synth(n_per_set, 1);
+        let eps_test = synth(n_per_set, 2);
+
+        // Forecasts: zeros (so the residual = the noise).
+        // Base "quantile" bounds: deliberately too tight at ±0.3, but the
+        // true 90% quantile of U(-1, 1) is ±0.9. CQR should expand to
+        // approximately ±0.9.
+        let q_lo_calib = vec![-0.3; n_per_set];
+        let q_hi_calib = vec![0.3; n_per_set];
+        let q_lo_test = vec![-0.3; n_per_set];
+        let q_hi_test = vec![0.3; n_per_set];
+
+        let cqr = CqrPredictor::new(0.90);
+        let result = cqr.fit(&q_lo_calib, &q_hi_calib, &eps_calib).unwrap();
+        let intervals = result.predict_intervals(&q_lo_test, &q_hi_test).unwrap();
+
+        let cov = intervals.empirical_coverage(&eps_test).unwrap();
+        // Stationary case: CQR coverage should land near nominal 0.90.
+        assert!(
+            (0.85..0.95).contains(&cov),
+            "CQR empirical coverage {:.3} should be near 0.90 (stationary case)",
+            cov
+        );
+    }
+}

--- a/src/postprocess/enbpi.rs
+++ b/src/postprocess/enbpi.rs
@@ -1,0 +1,393 @@
+//! Ensemble Bootstrap Prediction Intervals (EnbPI).
+//!
+//! Xu, C., & Xie, Y. (2021).
+//! *Conformal prediction interval for dynamic time-series.*
+//! ICML 2021.
+//!
+//! EnbPI builds prediction intervals from K bootstrap-trained model
+//! ensembles, computing leave-one-out (LOO) residuals from the ensemble
+//! prediction that **excludes** the bootstrap samples containing the
+//! target point. The (1-α) quantile of these residuals is the interval
+//! radius.
+//!
+//! Unlike Jackknife+, EnbPI does **not** require K full retraining passes
+//! — the K models are trained once on bootstrap resamples (the natural
+//! ensemble structure of bagging). The LOO is computed at *prediction*
+//! time by ensemble masking.
+//!
+//! The `EnbPiPredictor` is agnostic to how the K bootstrap models are
+//! produced: callers supply
+//!
+//! - `bootstrap_predictions: [n_train × K]` — prediction of each model on
+//!   each training point
+//! - `inclusion_mask: [n_train × K]` — `true` if training point i was
+//!   included in bootstrap sample k (used to construct LOO ensembles)
+//! - `actuals: [n_train]` — true values
+//!
+//! At prediction time, the model k's predictions on a new test set are
+//! also supplied (length `n_test × K`); EnbPI averages all K models to
+//! produce the point forecast and uses the LOO residual quantile for the
+//! interval radius.
+//!
+//! ## Online updates
+//!
+//! `update()` accepts new (forecast, actual) pairs and slides the residual
+//! window forward — adapts to distribution drift without retraining the
+//! ensemble.
+
+use crate::error::{ForecastError, Result};
+use crate::postprocess::PredictionIntervals;
+
+/// Result of fitting an EnbPI predictor.
+#[derive(Debug, Clone)]
+pub struct EnbPiResult {
+    /// Sorted leave-one-out absolute residuals on the training set.
+    residuals: Vec<f64>,
+    /// (1-α) quantile of the residuals — interval half-width.
+    quantile_value: f64,
+    /// Target coverage level (1-α).
+    coverage: f64,
+    /// Number of bootstrap models in the ensemble.
+    n_models: usize,
+}
+
+impl EnbPiResult {
+    pub fn residuals(&self) -> &[f64] {
+        &self.residuals
+    }
+
+    pub fn quantile_value(&self) -> f64 {
+        self.quantile_value
+    }
+
+    pub fn coverage(&self) -> f64 {
+        self.coverage
+    }
+
+    pub fn n_models(&self) -> usize {
+        self.n_models
+    }
+
+    /// Apply the calibrated radius to point forecasts.
+    pub fn predict_intervals(&self, point_forecasts: &[f64]) -> Result<PredictionIntervals> {
+        let lower: Vec<f64> = point_forecasts
+            .iter()
+            .map(|&p| p - self.quantile_value)
+            .collect();
+        let upper: Vec<f64> = point_forecasts
+            .iter()
+            .map(|&p| p + self.quantile_value)
+            .collect();
+        PredictionIntervals::from_bounds(lower, upper, self.coverage)
+    }
+
+    /// Slide the residual window forward with new (forecast, actual)
+    /// observations — keeps the most recent `max_window` residuals and
+    /// recomputes the quantile. Use this for online operation under drift.
+    pub fn update(
+        &mut self,
+        new_forecasts: &[f64],
+        new_actuals: &[f64],
+        max_window: usize,
+    ) -> Result<()> {
+        if new_forecasts.len() != new_actuals.len() {
+            return Err(ForecastError::DimensionMismatch {
+                expected: new_forecasts.len(),
+                got: new_actuals.len(),
+            });
+        }
+        // Append new residuals (kept unsorted for cheap append).
+        let mut all: Vec<f64> = self.residuals.clone();
+        for (f, a) in new_forecasts.iter().zip(new_actuals.iter()) {
+            all.push((f - a).abs());
+        }
+        // Trim to most recent max_window observations.
+        if all.len() > max_window {
+            let drop = all.len() - max_window;
+            all.drain(..drop);
+        }
+        all.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n = all.len();
+        if n == 0 {
+            return Err(ForecastError::EmptyData);
+        }
+        let level = self.coverage * (n as f64 + 1.0) / n as f64;
+        let level = level.min(1.0);
+        let idx = ((n as f64) * level).ceil() as usize;
+        let idx = idx.saturating_sub(1).min(n - 1);
+        self.quantile_value = all[idx];
+        self.residuals = all;
+        Ok(())
+    }
+}
+
+/// EnbPI predictor.
+///
+/// Coverage is the only configuration parameter at construction time —
+/// the ensemble structure is supplied at fit time.
+#[derive(Debug, Clone)]
+pub struct EnbPiPredictor {
+    coverage: f64,
+}
+
+impl EnbPiPredictor {
+    /// # Panics
+    /// Panics if coverage is not in (0, 1).
+    pub fn new(coverage: f64) -> Self {
+        assert!(
+            coverage > 0.0 && coverage < 1.0,
+            "coverage must be in (0, 1)"
+        );
+        Self { coverage }
+    }
+
+    pub fn coverage(&self) -> f64 {
+        self.coverage
+    }
+
+    /// Fit EnbPI on a bootstrap ensemble.
+    ///
+    /// # Arguments
+    /// * `bootstrap_predictions` — flat `[n_train * n_models]` row-major
+    ///   matrix: `predictions[i * n_models + k]` = model k's prediction on
+    ///   training point i
+    /// * `inclusion_mask` — flat `[n_train * n_models]`: `mask[i * K + k]`
+    ///   is `true` iff training point i was included in bootstrap sample
+    ///   k. Used to compute the LOO ensemble for point i.
+    /// * `actuals` — true values for each training point
+    /// * `n_models` — K, the number of bootstrap models in the ensemble
+    pub fn fit(
+        &self,
+        bootstrap_predictions: &[f64],
+        inclusion_mask: &[bool],
+        actuals: &[f64],
+        n_models: usize,
+    ) -> Result<EnbPiResult> {
+        if n_models == 0 {
+            return Err(ForecastError::InvalidParameter(
+                "n_models must be ≥ 1".to_string(),
+            ));
+        }
+        let n = actuals.len();
+        if n == 0 {
+            return Err(ForecastError::EmptyData);
+        }
+        let expected = n * n_models;
+        if bootstrap_predictions.len() != expected {
+            return Err(ForecastError::DimensionMismatch {
+                expected,
+                got: bootstrap_predictions.len(),
+            });
+        }
+        if inclusion_mask.len() != expected {
+            return Err(ForecastError::DimensionMismatch {
+                expected,
+                got: inclusion_mask.len(),
+            });
+        }
+
+        // For each training point i, compute the LOO ensemble prediction:
+        // average over models k where i was NOT in bootstrap sample k.
+        // Fall back to full ensemble average when no model excludes i.
+        let mut residuals: Vec<f64> = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut sum = 0.0;
+            let mut count = 0usize;
+            let mut full_sum = 0.0;
+            for k in 0..n_models {
+                let pred = bootstrap_predictions[i * n_models + k];
+                full_sum += pred;
+                if !inclusion_mask[i * n_models + k] {
+                    sum += pred;
+                    count += 1;
+                }
+            }
+            let loo_pred = if count > 0 {
+                sum / count as f64
+            } else {
+                full_sum / n_models as f64
+            };
+            residuals.push((loo_pred - actuals[i]).abs());
+        }
+
+        residuals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let level = self.coverage * (n as f64 + 1.0) / n as f64;
+        let level = level.min(1.0);
+        let idx = ((n as f64) * level).ceil() as usize;
+        let idx = idx.saturating_sub(1).min(n - 1);
+        let quantile_value = residuals[idx];
+
+        Ok(EnbPiResult {
+            residuals,
+            quantile_value,
+            coverage: self.coverage,
+            n_models,
+        })
+    }
+
+    /// Compute the ensemble point forecast for new test data by averaging
+    /// the K bootstrap models' predictions.
+    ///
+    /// # Arguments
+    /// * `test_predictions` — flat `[n_test * n_models]` row-major matrix
+    /// * `n_models` — K
+    pub fn ensemble_point_forecast(
+        &self,
+        test_predictions: &[f64],
+        n_models: usize,
+    ) -> Result<Vec<f64>> {
+        if n_models == 0 {
+            return Err(ForecastError::InvalidParameter(
+                "n_models must be ≥ 1".to_string(),
+            ));
+        }
+        if test_predictions.len() % n_models != 0 {
+            return Err(ForecastError::DimensionMismatch {
+                expected: test_predictions.len() / n_models * n_models,
+                got: test_predictions.len(),
+            });
+        }
+        let n_test = test_predictions.len() / n_models;
+        let mut result = Vec::with_capacity(n_test);
+        for i in 0..n_test {
+            let mut sum = 0.0;
+            for k in 0..n_models {
+                sum += test_predictions[i * n_models + k];
+            }
+            result.push(sum / n_models as f64);
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic ensemble where every model gives the same
+    /// prediction `actuals + noise[k]` and check that the residuals
+    /// match the expected magnitude.
+    #[test]
+    fn fit_recovers_noise_magnitude() {
+        let n = 100;
+        let n_models = 5;
+        let actuals: Vec<f64> = (0..n).map(|i| (i as f64 * 0.1).sin()).collect();
+
+        // Each model adds a different constant offset (no per-row noise).
+        // The LOO ensemble for any given i averages 4 of 5 offsets.
+        let model_offsets = [-0.2, -0.1, 0.0, 0.1, 0.2];
+        let mut predictions: Vec<f64> = Vec::with_capacity(n * n_models);
+        for i in 0..n {
+            for k in 0..n_models {
+                predictions.push(actuals[i] + model_offsets[k]);
+            }
+        }
+        // Inclusion mask: model k included point i iff (i + k) is even.
+        let mut mask: Vec<bool> = Vec::with_capacity(n * n_models);
+        for i in 0..n {
+            for k in 0..n_models {
+                mask.push((i + k) % 2 == 0);
+            }
+        }
+
+        let enbpi = EnbPiPredictor::new(0.90);
+        let result = enbpi.fit(&predictions, &mask, &actuals, n_models).unwrap();
+
+        // Residuals should be small and positive.
+        assert_eq!(result.residuals().len(), n);
+        assert!(result.quantile_value() >= 0.0);
+        // The maximum possible LOO offset is bounded by max(|model_offsets|) ≈ 0.2.
+        assert!(
+            result.quantile_value() < 0.4,
+            "quantile value {} too large for offsets ≤ 0.2",
+            result.quantile_value()
+        );
+    }
+
+    #[test]
+    fn predict_intervals_widens_around_point_forecast() {
+        // Trivial setup: every model predicts the actual exactly.
+        let n = 50;
+        let n_models = 3;
+        let actuals: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let mut predictions: Vec<f64> = Vec::with_capacity(n * n_models);
+        for i in 0..n {
+            for _k in 0..n_models {
+                predictions.push(actuals[i]);
+            }
+        }
+        let mask: Vec<bool> = vec![false; n * n_models]; // all LOO
+
+        // Add a known offset to make residuals non-zero
+        let mut perturbed = predictions.clone();
+        for p in perturbed.iter_mut() {
+            *p += 0.5;
+        }
+
+        let enbpi = EnbPiPredictor::new(0.90);
+        let result = enbpi.fit(&perturbed, &mask, &actuals, n_models).unwrap();
+
+        // All residuals are exactly 0.5 → quantile = 0.5
+        assert!((result.quantile_value() - 0.5).abs() < 1e-12);
+
+        let test_pf = vec![10.0, 20.0, 30.0];
+        let intervals = result.predict_intervals(&test_pf).unwrap();
+        assert!((intervals.lower()[0] - 9.5).abs() < 1e-12);
+        assert!((intervals.upper()[0] - 10.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ensemble_point_forecast_averages_models() {
+        let n_test = 3;
+        let n_models = 4;
+        let test = vec![
+            1.0, 2.0, 3.0, 4.0, // i=0: mean = 2.5
+            10.0, 20.0, 30.0, 40.0, // i=1: mean = 25.0
+            5.0, 5.0, 5.0, 5.0, // i=2: mean = 5.0
+        ];
+        let enbpi = EnbPiPredictor::new(0.90);
+        let pf = enbpi.ensemble_point_forecast(&test, n_models).unwrap();
+        assert_eq!(pf, vec![2.5, 25.0, 5.0]);
+        let _ = n_test;
+    }
+
+    #[test]
+    fn online_update_slides_window() {
+        let actuals: Vec<f64> = (0..50).map(|i| i as f64).collect();
+        let preds: Vec<f64> = actuals.iter().map(|&a| a + 0.5).collect();
+        let mask = vec![false; 50 * 1];
+
+        let enbpi = EnbPiPredictor::new(0.90);
+        let mut result = enbpi.fit(&preds, &mask, &actuals, 1).unwrap();
+
+        // Initial radius = 0.5
+        assert!((result.quantile_value() - 0.5).abs() < 1e-12);
+
+        // Update with larger errors: forecasts off by 1.5
+        let new_actuals = vec![100.0, 101.0, 102.0];
+        let new_preds = vec![101.5, 102.5, 103.5];
+        result.update(&new_preds, &new_actuals, 30).unwrap();
+
+        // After sliding to a 30-window dominated by 0.5 errors,
+        // the new larger errors should pull the quantile up but stay close.
+        assert!(result.quantile_value() >= 0.5);
+        assert!(result.residuals().len() <= 30);
+    }
+
+    #[test]
+    fn empty_data_errors() {
+        let enbpi = EnbPiPredictor::new(0.90);
+        let err = enbpi.fit(&[], &[], &[], 1).unwrap_err();
+        assert!(matches!(err, ForecastError::EmptyData));
+    }
+
+    #[test]
+    fn dimension_mismatch_errors() {
+        let enbpi = EnbPiPredictor::new(0.90);
+        // 2 actuals × 3 models = 6 expected slots, but only 5 supplied
+        let err = enbpi
+            .fit(&[1.0, 2.0, 3.0, 4.0, 5.0], &[false; 6], &[1.0, 2.0], 3)
+            .unwrap_err();
+        assert!(matches!(err, ForecastError::DimensionMismatch { .. }));
+    }
+}

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -27,11 +27,14 @@
 //! let intervals = cp.predict(&forecasts);
 //! ```
 
+mod aci;
 mod backtest;
 mod binned_intervals;
 mod bootstrap;
 mod conformal;
 mod conformalize;
+mod cqr;
+mod enbpi;
 mod historical_sim;
 mod idr;
 mod normal;
@@ -39,6 +42,7 @@ mod processor;
 mod qra;
 mod types;
 
+pub use aci::AciPredictor;
 pub use backtest::{BacktestConfig, BacktestFold, BacktestResult, CalibratedModelByHorizon};
 pub use binned_intervals::{BinnedConformalPredictor, BinnedConformalResult};
 pub use bootstrap::{BootstrapPredictor, BootstrapResult};
@@ -46,6 +50,8 @@ pub use conformal::{ConformalMethod, ConformalPredictor, ConformalResult, PerSte
 pub use conformalize::{
     conformalize, conformalize_with_config, ConformalizeConfig, ConformalizeResult,
 };
+pub use cqr::{CqrPredictor, CqrResult};
+pub use enbpi::{EnbPiPredictor, EnbPiResult};
 pub use historical_sim::{HistoricalSimResult, HistoricalSimulator};
 pub use idr::{IDRPredictor, IDRResult};
 pub use normal::{NormalPredictor, NormalResult};


### PR DESCRIPTION
## Summary

Three new conformal prediction methods, all behind the existing `postprocess` feature flag. No breaking changes.

| Method | File | Reference |
|---|---|---|
| **CQR** — Conformalized Quantile Regression | `src/postprocess/cqr.rs` | Romano, Patterson & Candès, NeurIPS 2019 |
| **EnbPI** — Ensemble Bootstrap Prediction Interval | `src/postprocess/enbpi.rs` | Xu & Xie, ICML 2021 |
| **ACI** — Adaptive Conformal Inference | `src/postprocess/aci.rs` | Gibbs & Candès, NeurIPS 2021 |

### CQR
Wraps any quantile-regression base learner. Conformity score `E_i = max(q_lo - y_i, y_i - q_hi_i)`. Symmetric bound adjustment by Q = (1−α)(n+1)/n quantile of E_i. Tighter than absolute-residual conformal under heteroscedasticity.

### EnbPI
Leave-one-out residuals from a bagged ensemble. Caller supplies K bootstrap predictions + inclusion mask; no retraining needed. `update()` slides the residual window forward for online drift adaptation.

### ACI
Stateful streaming wrapper: `α_{t+1} = α_t + γ * (α_target - err_t)`. α_t clamped to (0.001, 0.999) to avoid radius oscillation between 0 and max-residual at the boundaries. Long-run coverage provably converges to target under arbitrary distribution drift.

## Test plan

- [x] 22 new tests, all pass
- [x] CQR: stationary holdout coverage in [0.85, 0.95] for 0.90 nominal target
- [x] EnbPI: residual recovery, ensemble point forecasting, online window update
- [x] ACI: drift response (radius widens after distribution shift), long-run coverage convergence
- [x] 2785 total lib tests pass
- [x] `cargo clippy --lib --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)