### PR TITLE
Release v0.7.4: feature engineering expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-05-07
+
 ### Added
 
 - **Rolling-feature kinds**: `RollingStatKind` gains `Quantile { tau }`, `Range`, `Iqr`, `Skew`, `Kurt`, `Slope` (OLS slope), `Rank` (fractional rank of latest value), `ZScore`, `CountAbove { threshold }`, `CountBelow { threshold }`. Convenience builders on `RegressionFeatures`: `with_rolling_quantile`, `with_rolling_range`, `with_rolling_iqr`, `with_rolling_skew`, `with_rolling_kurt`, `with_rolling_slope`, `with_rolling_rank`, `with_rolling_zscore`, `with_rolling_count_above`, `with_rolling_count_below`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.7.3"
+anofox-forecast = "0.7.4"
 ```
 
 ### Optional Features


### PR DESCRIPTION
## Summary

Bumps the crate from \`0.7.3\` to \`0.7.4\`. All additions since 0.7.3 are non-breaking (new types, new builder methods, new modules behind existing feature flags) — patch-level bump, same pattern as 0.7.2 → 0.7.3.

## What's new since 0.7.3

Six PRs of feature-engineering work; five issues closed.

| Area | PRs |
|---|---|
| Rolling stats expansion (10 new variants), EventDistanceFeature, exog Lag/Rolling, MI selection | #86 |
| Polynomial + interaction exog features (closes #81) | #87 |
| Categorical encoding — OneHot/Ordinal/Count/Target (closes #82) | #88 |
| Yeo-Johnson transform (closes #83) | #89 |
| Cross-series panel aggregations (closes #84) | #90 |
| VIF + condition number diagnostic (closes #85) | #91 |

Test count: 2785 → 2843 (+58).

## Files changed

- \`Cargo.toml\` — version 0.7.3 → 0.7.4
- \`Cargo.lock\` — synced
- \`CHANGELOG.md\` — section [Unreleased] cut to [0.7.4] - 2026-05-07
- \`README.md\` — install snippet bumped

(README API references for the new features were merged with the corresponding feature PRs; this PR just bumps the version sticker.)

## Test plan

- [x] \`cargo test --lib --all-features\` — 2843 pass
- [x] \`cargo clippy --lib --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — applied
- [ ] CI on PR
- [ ] After merge: tag \`v0.7.4\` to trigger crates.io + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)