### PR TITLE
Release v0.7.5: ruptures-parity changepoint detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-05-13
+
 ### Added
 
 - **Full [`ruptures`](https://github.com/deepcharles/ruptures)-parity changepoint surface** in `src/changepoint/`. New trait-based API lives alongside the existing free-function one (`pelt_detect`, `PeltConfig`, `CostFunction` enum unchanged). Mirrors `ruptures` 1.1.9.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.7.4"
+anofox-forecast = "0.7.5"
 ```
 
 ### Optional Features


### PR DESCRIPTION
## Summary

Bumps the crate from \`0.7.4\` to \`0.7.5\`. All additions since 0.7.4 are non-breaking (new trait-based API lives alongside the existing free-function one) — patch-level bump.

## What's new since 0.7.4

Three PRs landed on main since v0.7.4:

| PR | Scope |
|---|---|
| #94 | v0.7.4 feature-engineering integration test (6 cross-feature scenarios with R² = 1 recovery) |
| #95 | Full ruptures-parity changepoint surface — 5 phases in one PR: traits + Signal carrier + 6 detectors + 14 cost functions + 3 metrics + Python fixture generator + parity tests against \`ruptures==1.1.9\` |
| #96 | Documentation backfill for the changepoint work (CHANGELOG, README, fixtures README) |

Test count: 2843 → 2912 (+69) + 5 parity integration tests + 6 v0.7.4 feature-engineering integration tests.

## Files changed in this PR

- \`Cargo.toml\` — version 0.7.4 → 0.7.5
- \`Cargo.lock\` — synced
- \`CHANGELOG.md\` — section \`[Unreleased]\` cut to \`[0.7.5] - 2026-05-13\`
- \`README.md\` — install snippet bumped

(All feature documentation already landed via #95 and #96; this PR is just the version sticker.)

## Test plan

- [x] \`cargo test --lib --all-features\` — 2912 pass
- [x] \`cargo clippy --lib --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — applied
- [ ] CI on PR
- [ ] After merge: tag \`v0.7.5\` to trigger crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)