### PR TITLE
Release v0.7.6: WeightStrategy::Logistic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-05-31
+
 ### Added
 
 - **`WeightStrategy::Logistic { offset }`** (closes #98) — sigmoid recency weights for `RegressionForecaster::wls(…)`. Weight at observation `i` of an `n`-row training set is `1 / (1 + exp(-((i as f64) - (n as f64 - offset))))`, so the last ~`offset` observations contribute near 1.0 and older ones decay through a single inflection point and plateau near 0. Convenience constructor `RegressionForecaster::wls_logistic(offset, features)` mirrors the existing `wls_decay`. Different shape from `ExponentialDecay`: smooth plateaus at both ends with a single inflection, rather than monotonic geometric decay.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.7.5"
+anofox-forecast = "0.7.6"
 ```
 
 ### Optional Features


### PR DESCRIPTION
## Summary

Bumps the crate from \`0.7.5\` to \`0.7.6\`. Single non-breaking addition since 0.7.5 — patch-level bump.

## What's new since 0.7.5

| PR | Scope |
|---|---|
| #100 | \`WeightStrategy::Logistic { offset }\` + \`RegressionForecaster::wls_logistic(offset, features)\` for sigmoid recency weighting (closes #98) |

Test count: 2912 → 2915 (+3).

## Files changed in this PR

- \`Cargo.toml\` — version 0.7.5 → 0.7.6
- \`Cargo.lock\` — synced
- \`CHANGELOG.md\` — section \`[Unreleased]\` cut to \`[0.7.6] - 2026-05-31\`
- \`README.md\` — install snippet bumped

## Test plan

- [x] \`cargo test --lib --all-features\` — 2915 pass
- [x] \`cargo clippy --lib --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — applied
- [ ] CI on PR
- [ ] After merge: tag \`v0.7.6\` to trigger crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)