### PR TITLE
Lock-step JS version 0.6.0 → 0.7.6 + document OIDC release flow

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -104,6 +104,10 @@ jobs:
           echo "package.json:"
           cat js/package.json
 
+      # OIDC-only publish. Auth comes from npm's trusted-publisher config
+      # (configured for this repo + workflow on npmjs.com), tied to the
+      # `id-token: write` permission above. The `--provenance` flag emits
+      # the supply-chain attestation alongside the publish.
       - name: Publish to npm (dry run)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         working-directory: js

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.6.0"
+version = "0.7.6"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.6.0",
+  "version": "0.7.6",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/docs/npm_release.md
+++ b/docs/npm_release.md
@@ -1,0 +1,75 @@
+# npm release process
+
+The `anofox-forecast-js` WASM package is published to npm automatically when
+a GitHub release is published. The workflow lives at
+[`.github/workflows/npm.yml`](../.github/workflows/npm.yml).
+
+## Authentication
+
+Publishing uses **npm's OIDC trusted-publisher flow** — no static token,
+no `NPM_TOKEN` secret. Auth is bound to the GitHub Actions runner via the
+`id-token: write` permission and signed by GitHub's OIDC issuer.
+
+The trust is configured on the npm side (one-time, by the package owner):
+
+- Package: `anofox-forecast-js`
+- Repository: `sipemu/anofox-forecast`
+- Workflow filename: `npm.yml`
+- Permissions: `npm publish`
+
+Configured via **npmjs.com → Package settings → Trusted Publisher → GitHub
+Actions**.
+
+## Release flow
+
+1. Bump `crates/anofox-forecast-js/Cargo.toml` **and**
+   `crates/anofox-forecast-js/package.json` to the new version. We keep
+   them in lock-step with the Rust crate's version.
+2. Land the version bump on `main`.
+3. Cut a GitHub release on the matching tag (e.g. `v0.7.6`). The release
+   event triggers `npm.yml`, which:
+   - builds the WASM package via `wasm-pack build --target web`,
+   - restores the hand-written `package.json` + `README.md` + `types.d.ts`,
+   - runs `npm publish --access public --provenance`.
+4. The published artifact appears at
+   https://www.npmjs.com/package/anofox-forecast-js with provenance attestation.
+
+## Manual dispatch (dry run)
+
+To verify the pipeline without an actual publish:
+
+```bash
+gh workflow run npm.yml --ref main -f dry_run=true
+gh run watch
+```
+
+The "Publish to npm (dry run)" step should report a successful tarball
+prep and no `ENEEDAUTH` / `403` errors.
+
+## Troubleshooting
+
+### `ENEEDAUTH` on publish
+
+- Trusted publisher not configured (or misconfigured) on the npm side
+  for this package + workflow. Verify at
+  https://www.npmjs.com/package/anofox-forecast-js/access.
+- `id-token: write` permission missing from the `publish-npm` job.
+
+### `403 Forbidden`
+
+- Trusted publisher trust record doesn't match the runtime — usually
+  caused by a typo in the workflow filename or repo name on the npm
+  side. Workflow filename must be exactly `npm.yml`.
+
+### `provenance` failures
+
+- Requires npm ≥ 11.5.1; the workflow's "Upgrade npm for OIDC support"
+  step handles this.
+- Requires `id-token: write` permission (already set in the workflow).
+
+### Version-mismatch errors
+
+The `package.json` and Rust `Cargo.toml` versions must match. The build
+job restores both from git after `wasm-pack` clobbers the
+`package.json`, so a mismatch usually means one was bumped and not the
+other.


### PR DESCRIPTION
## Summary

Two changes that unblock the first npm publish of \`anofox-forecast-js\`:

1. **Lock-step version bump** \`0.6.0 → 0.7.6\` in both \`crates/anofox-forecast-js/Cargo.toml\` and \`crates/anofox-forecast-js/package.json\`, so the first npm publish ships at the same version as the Rust crate.
2. **\`docs/npm_release.md\` (new)** — end-to-end runbook for the OIDC trusted-publisher flow, plus troubleshooting for the failure modes hit since v0.7.3.

The auth piece was on the npm side: trusted publisher had to be configured for \`anofox-forecast-js\` pointing at this repo + \`npm.yml\` workflow. **That's now done.** With that in place, the workflow's existing OIDC machinery (\`id-token: write\` + \`--provenance\`) is enough — no NPM_TOKEN secret, no \`registry-url\` on \`setup-node\`, just OIDC.

(An earlier revision of this PR added \`NODE_AUTH_TOKEN\` env as a bootstrap fallback. Reverted in the latest force-push since trusted publisher is configured.)

## Next step after merge

1. Verify with a dry run:
   \`\`\`bash
   gh workflow run npm.yml --ref main -f dry_run=true
   gh run watch
   \`\`\`
2. Either re-trigger the v0.7.6 release event (\`gh release edit v0.7.6 --draft && gh release edit v0.7.6 --draft=false\`) or run the workflow without \`dry_run\` to publish.

## Test plan

- [x] \`cargo check -p anofox-forecast-js --target wasm32-unknown-unknown\` — builds clean
- [x] YAML lint — valid
- [ ] CI on PR (does not exercise publish, since this is not a release event)
- [ ] After merge: dry-run, then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)