### PR TITLE
Fix js/package.json: restore @sipemu/anofox-forecast name + bump to 0.7.6

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "anofox-forecast-js",
+  "name": "@sipemu/anofox-forecast",
   "type": "module",
   "collaborators": [
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.5.1",
+  "version": "0.7.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Real root cause found

The npm package is **\`@sipemu/anofox-forecast\`** — scoped, 12 versions published, last at 0.5.1, all via OIDC trusted publisher successfully. \`npm view @sipemu/anofox-forecast\` confirms this.

Somewhere after 0.5.1 the tracked \`js/package.json\` was renamed to the unscoped name \`anofox-forecast-js\` and the version stayed at 0.5.1. The workflow restores \`js/package.json\` via \`git checkout\` after \`wasm-pack build\`, so every recent publish attempt has been shipping a tarball under \`anofox-forecast-js@0.5.1\` — a brand-new unscoped name with no trusted-publisher config.

That's the entire reason for the \`ENEEDAUTH\` failures since v0.7.3:

\`\`\`
npm notice 📦  anofox-forecast-js@0.5.1   ← wrong name AND wrong version
npm error code ENEEDAUTH                  ← because trusted publisher
                                            is configured for the
                                            scoped name, not this one
\`\`\`

## Fix

\`js/package.json\`:
- \`"name"\`: \`anofox-forecast-js\` → \`@sipemu/anofox-forecast\` (matches the actual published package; trusted publisher already applies)
- \`"version"\`: \`0.5.1\` → \`0.7.6\` (lock-step with the Rust crate)

That's it. No workflow changes needed. No NPM_TOKEN bootstrap needed. The existing OIDC trusted-publisher config will be honoured.

## Test plan

- [x] \`js/package.json\` carries the scoped name and v0.7.6
- [ ] CI on PR
- [ ] After merge: \`gh workflow run npm.yml --ref main -f dry_run=true\` then real publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)