### PR TITLE
Issue #107: Inspectable trait + Explanation enum across the forecasting catalog

### DIFF
--- a/src/models/arima/auto_arima.rs
+++ b/src/models/arima/auto_arima.rs
@@ -4,6 +4,7 @@ use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
 use crate::models::arima::diff::suggest_differencing;
 use crate::models::arima::model::{ARIMA, SARIMA};
+use crate::models::inspect::{ArimaExplanation, Explanation, Inspectable};
 use crate::models::{validate_series_complete, Forecaster};
 use crate::utils::ols::OLSResult;
 
@@ -1087,6 +1088,71 @@ impl Forecaster for AutoARIMA {
             }
             None => Err(ForecastError::FitRequired { model: None }),
         }
+    }
+}
+
+impl Inspectable for AutoARIMA {
+    fn explanation(&self) -> Result<Explanation> {
+        let model = self
+            .selected_model
+            .as_ref()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoARIMA".to_string()),
+            })?;
+        let order = self
+            .selected_order
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoARIMA".to_string()),
+            })?;
+
+        let (coefficients, aic, bic, fitted_values, residuals) = match model {
+            SelectedModel::ARIMA(m) => {
+                let mut coeffs = Vec::new();
+                coeffs.extend_from_slice(m.ar_coefficients());
+                coeffs.extend_from_slice(m.ma_coefficients());
+                let f = m.fitted_values().map(|v| v.to_vec()).unwrap_or_default();
+                let r = m.residuals().map(|v| v.to_vec()).unwrap_or_default();
+                (
+                    coeffs,
+                    m.aic().unwrap_or(f64::NAN),
+                    m.bic().unwrap_or(f64::NAN),
+                    f,
+                    r,
+                )
+            }
+            SelectedModel::SARIMA(m) => {
+                let mut coeffs = Vec::new();
+                coeffs.extend_from_slice(m.ar_coefficients());
+                coeffs.extend_from_slice(m.ma_coefficients());
+                coeffs.extend_from_slice(m.seasonal_ar_coefficients());
+                coeffs.extend_from_slice(m.seasonal_ma_coefficients());
+                let f = m.fitted_values().map(|v| v.to_vec()).unwrap_or_default();
+                let r = m.residuals().map(|v| v.to_vec()).unwrap_or_default();
+                (
+                    coeffs,
+                    m.aic().unwrap_or(f64::NAN),
+                    m.bic().unwrap_or(f64::NAN),
+                    f,
+                    r,
+                )
+            }
+        };
+
+        let seasonal_order = if order.is_seasonal() {
+            Some((order.cap_p, order.cap_d, order.cap_q, order.s))
+        } else {
+            None
+        };
+
+        Ok(Explanation::Arima(ArimaExplanation {
+            order: (order.p, order.d, order.q),
+            seasonal_order,
+            coefficients,
+            aic,
+            bic,
+            fitted_values,
+            residuals,
+        }))
     }
 }
 

--- a/src/models/exponential/auto_ets.rs
+++ b/src/models/exponential/auto_ets.rs
@@ -6,6 +6,7 @@
 use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
 use crate::models::exponential::ets::{ETSSpec, ErrorType, SeasonalType, TrendType, ETS};
+use crate::models::inspect::{EtsExplanation, Explanation, Inspectable};
 use crate::models::{validate_series_complete, Forecaster};
 use crate::utils::ols::{ols_fit, ols_residuals, OLSResult};
 use std::borrow::Cow;
@@ -751,6 +752,51 @@ impl Forecaster for AutoETS {
             }
             Ok(base_forecast)
         }
+    }
+}
+
+impl Inspectable for AutoETS {
+    fn explanation(&self) -> Result<Explanation> {
+        let model = self
+            .selected_model
+            .as_ref()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoETS".to_string()),
+            })?;
+        let spec = self
+            .selected_spec
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoETS".to_string()),
+            })?;
+
+        let fitted_values = model
+            .fitted_values()
+            .map(|v| v.to_vec())
+            .unwrap_or_default();
+        let residuals = model.residuals().map(|v| v.to_vec()).unwrap_or_default();
+        let trend_component = self
+            .trend_component()
+            .ok()
+            .map(|v| v.to_vec())
+            .unwrap_or_default();
+        let seasonal_component = if spec.has_seasonal() {
+            self.seasonal_component().ok().map(|v| v.to_vec())
+        } else {
+            None
+        };
+
+        Ok(Explanation::Ets(EtsExplanation {
+            spec: spec.short_name(),
+            alpha: model.alpha().unwrap_or(f64::NAN),
+            beta: model.beta(),
+            gamma: model.gamma(),
+            phi: model.phi(),
+            seasonal_period: self.config.seasonal_period.unwrap_or(0),
+            fitted_values,
+            trend_component,
+            seasonal_component,
+            residuals,
+        }))
     }
 }
 

--- a/src/models/inspect.rs
+++ b/src/models/inspect.rs
@@ -1,0 +1,276 @@
+//! Fit-state inspection trait + per-model typed payloads.
+//!
+//! `Inspectable` is the typed sibling to [`Explainable`](super::explain::Explainable).
+//! Where `Explainable` decomposes a *forecast* into level / trend /
+//! seasonal so callers can reconstruct the prediction, `Inspectable`
+//! packages the *fit*: the model's internal state and interpretable
+//! parameters as a single per-fit snapshot consumers can serialise,
+//! cache, and surface to UIs.
+//!
+//! Issue #107. Builds on the primitive accessors from #106
+//! (`fitted_values`, `trend_component`, `seasonal_component`,
+//! `residual_component`, `training_values`).
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use anofox_forecast::models::{Forecaster, Inspectable, Explanation};
+//!
+//! let mut model = AutoETS::new();
+//! model.fit(&ts)?;
+//! match model.explanation()? {
+//!     Explanation::Ets(e) => println!("spec {} alpha {:.3}", e.spec, e.alpha),
+//!     _ => unreachable!(),
+//! }
+//! ```
+
+use crate::error::Result;
+
+/// Snapshot of a model's most recent fit.
+///
+/// Each variant carries the universal spine (fitted values, residuals)
+/// plus model-specific scalars and structural components. Variants are
+/// owned (no borrows) so `Explanation` can be serialised, cached, and
+/// sent across process boundaries.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Explanation {
+    /// Regression models (`RegressionForecaster`, OLS / Ridge / WLS / etc.).
+    Regression(RegressionExplanation),
+    /// ETS family (`SimpleES`, `HoltLinear`, `HoltWinters`, `SeasonalES`, `AutoETS`).
+    Ets(EtsExplanation),
+    /// ARIMA family (`AutoARIMA`).
+    Arima(ArimaExplanation),
+    /// MFLES (the boosted MFLES forecaster).
+    Mfles(MflesExplanation),
+    /// Theta family (`AutoTheta`, `DynamicTheta`, `OptimizedTheta`).
+    Theta(ThetaExplanation),
+    /// TBATS family (`AutoTBATS`).
+    Tbats(TbatsExplanation),
+    /// MSTL (`MSTLForecaster`).
+    Mstl(MstlExplanation),
+}
+
+/// Interpretable state for regression-backed forecasters.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RegressionExplanation {
+    /// Named feature columns in the order they appear in `coefficients`.
+    pub feature_names: Vec<String>,
+    /// Coefficients aligned with `feature_names`.
+    pub coefficients: Vec<f64>,
+    /// Intercept term (separated out from `coefficients`).
+    pub intercept: f64,
+    /// In-sample R² (1 − RSS / TSS).
+    pub r_squared: f64,
+    /// Backend identifier, e.g. `"ols"`, `"ridge"`, `"wls_logistic"`.
+    pub backend: String,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for ETS-family forecasters.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct EtsExplanation {
+    /// ETS spec identifier (e.g. `"AAA"`, `"ANN"`, `"MAM"`).
+    pub spec: String,
+    /// Level smoothing parameter.
+    pub alpha: f64,
+    /// Trend smoothing parameter; `None` for level-only specs.
+    pub beta: Option<f64>,
+    /// Seasonal smoothing parameter; `None` for non-seasonal specs.
+    pub gamma: Option<f64>,
+    /// Damping parameter for damped-trend specs.
+    pub phi: Option<f64>,
+    /// Seasonal period (0 for non-seasonal fits).
+    pub seasonal_period: usize,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// Trend component (from the #106 accessor). Same length as
+    /// `fitted_values` or shorter (warmup-dropped).
+    pub trend_component: Vec<f64>,
+    /// Seasonal component if available; `None` for non-seasonal fits.
+    pub seasonal_component: Option<Vec<f64>>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for ARIMA / SARIMA forecasters.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ArimaExplanation {
+    /// Non-seasonal order `(p, d, q)`.
+    pub order: (usize, usize, usize),
+    /// Seasonal order `(P, D, Q, s)` if present.
+    pub seasonal_order: Option<(usize, usize, usize, usize)>,
+    /// Fitted AR/MA coefficients.
+    pub coefficients: Vec<f64>,
+    /// AIC of the selected model.
+    pub aic: f64,
+    /// BIC of the selected model.
+    pub bic: f64,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for MFLES.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MflesExplanation {
+    /// Seasonal period (0 for non-seasonal).
+    pub seasonal_period: usize,
+    /// Number of boosting rounds actually executed.
+    pub max_rounds: usize,
+    /// Whether multiplicative mode was used.
+    pub multiplicative: bool,
+    /// Trend penalty (R²-based shrinkage), if computed.
+    pub penalty: Option<f64>,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// Per-row trend component.
+    pub trend_component: Vec<f64>,
+    /// Per-row seasonal contribution (defined as `fitted - trend` so the
+    /// invariant `trend + seasonal + residual = training` holds in both
+    /// additive and multiplicative modes).
+    pub seasonal_component: Vec<f64>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for Theta-family forecasters.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ThetaExplanation {
+    /// Selected Theta variant identifier (e.g. `"StandardTheta"`,
+    /// `"OptimizedTheta"`, `"DynamicStandardTheta"`).
+    pub variant: String,
+    /// Theta parameter (default 2.0 in the standard model).
+    pub theta: f64,
+    /// Level smoothing parameter; `None` if the variant doesn't expose it.
+    pub alpha: Option<f64>,
+    /// Seasonal period (0 for non-seasonal fits).
+    pub seasonal_period: usize,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for TBATS.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TbatsExplanation {
+    /// Seasonal periods used in the fit.
+    pub seasonal_periods: Vec<usize>,
+    /// Box-Cox λ if the transformation was applied.
+    pub box_cox_lambda: Option<f64>,
+    /// Description of the selected configuration (trend / damping / Box-Cox flags).
+    pub selected_config: String,
+    /// AIC of the selected model.
+    pub aic: f64,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// In-sample residuals.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for MSTL.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MstlExplanation {
+    /// Seasonal periods used in the decomposition.
+    pub seasonal_periods: Vec<usize>,
+    /// Number of MSTL iterations.
+    pub iterations: usize,
+    /// In-sample fitted values.
+    pub fitted_values: Vec<f64>,
+    /// Per-row trend component (STL trend).
+    pub trend_component: Vec<f64>,
+    /// Per-row sum of all seasonal components.
+    pub seasonal_component: Vec<f64>,
+    /// Per-row STL remainder.
+    pub residuals: Vec<f64>,
+}
+
+/// Fit-state inspection trait.
+///
+/// Models that implement this expose a typed [`Explanation`] snapshot
+/// of their most recent fit. Not every forecaster implements this —
+/// baselines (`Naive`, `RandomWalkDrift`, …) and the intermittent-demand
+/// family don't have interpretable structure worth packaging.
+///
+/// `Box<dyn Inspectable>` works because `Explanation` is owned (no
+/// borrows in any variant).
+pub trait Inspectable {
+    /// Snapshot of the most recent fit.
+    ///
+    /// # Errors
+    /// Returns `Err(FitRequired)` if `fit()` hasn't been called yet, or
+    /// `Err(InvalidParameter)` if the model lacks the state needed to
+    /// build the snapshot.
+    fn explanation(&self) -> Result<Explanation>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explanation_variants_are_owned_and_clonable() {
+        // Smoke test: variants are owned, no lifetime parameters, so
+        // they Clone trivially.
+        let e = Explanation::Regression(RegressionExplanation {
+            feature_names: vec!["x".into()],
+            coefficients: vec![1.0],
+            intercept: 0.5,
+            r_squared: 0.9,
+            backend: "ols".into(),
+            fitted_values: vec![1.0, 2.0],
+            residuals: vec![0.1, -0.1],
+        });
+        let e2 = e.clone();
+        assert_eq!(e, e2);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn regression_explanation_round_trips_through_serde_json() {
+        let e = RegressionExplanation {
+            feature_names: vec!["intercept".into(), "lag_1".into()],
+            coefficients: vec![1.5, 0.8],
+            intercept: 1.5,
+            r_squared: 0.92,
+            backend: "ridge".into(),
+            fitted_values: vec![1.0, 2.0, 3.0],
+            residuals: vec![0.0, 0.1, -0.1],
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let e2: RegressionExplanation = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, e2);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn explanation_enum_round_trips_through_serde_json() {
+        let e = Explanation::Ets(EtsExplanation {
+            spec: "AAA".into(),
+            alpha: 0.3,
+            beta: Some(0.1),
+            gamma: Some(0.2),
+            phi: None,
+            seasonal_period: 12,
+            fitted_values: vec![10.0; 5],
+            trend_component: vec![1.0; 5],
+            seasonal_component: Some(vec![0.5; 5]),
+            residuals: vec![0.0; 5],
+        });
+        let json = serde_json::to_string(&e).unwrap();
+        let e2: Explanation = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, e2);
+    }
+}

--- a/src/models/mfles.rs
+++ b/src/models/mfles.rs
@@ -12,6 +12,7 @@
 
 use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
+use crate::models::inspect::{Explanation, Inspectable, MflesExplanation};
 use crate::models::{validate_series_complete, Forecaster};
 use crate::utils::ols::{ols_fit, ols_residuals, OLSResult};
 use std::collections::HashMap;
@@ -1566,6 +1567,34 @@ impl Forecaster for MFLES {
 
     fn name(&self) -> &str {
         "MFLES"
+    }
+}
+
+impl Inspectable for MFLES {
+    fn explanation(&self) -> Result<Explanation> {
+        let fitted = self
+            .fitted
+            .clone()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("MFLES".to_string()),
+            })?;
+        let residuals = self
+            .residuals
+            .clone()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("MFLES".to_string()),
+            })?;
+
+        Ok(Explanation::Mfles(MflesExplanation {
+            seasonal_period: self.season_length,
+            max_rounds: self.max_rounds,
+            multiplicative: self.is_multiplicative,
+            penalty: self.penalty,
+            fitted_values: fitted,
+            trend_component: self.trend_full.clone().unwrap_or_default(),
+            seasonal_component: self.seasonal_full.clone().unwrap_or_default(),
+            residuals,
+        }))
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 //! Forecasting models.
 
 pub mod explain;
+pub mod inspect;
 mod traits;
 
 pub mod arima;
@@ -22,6 +23,10 @@ pub mod var;
 pub mod var_forecaster;
 
 pub use garch::GARCH;
+pub use inspect::{
+    ArimaExplanation, EtsExplanation, Explanation, Inspectable, MflesExplanation, MstlExplanation,
+    RegressionExplanation, TbatsExplanation, ThetaExplanation,
+};
 pub use kalman_forecaster::KalmanForecaster;
 pub use mfles::MFLES;
 pub use mstl_forecaster::{MSTLForecaster, SeasonalForecastMethod, TrendForecastMethod};

--- a/src/models/mstl_forecaster.rs
+++ b/src/models/mstl_forecaster.rs
@@ -11,6 +11,7 @@ use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
 use crate::models::explain::{Explainable, ForecastExplanation};
 use crate::models::exponential::{AutoETS, AutoETSConfig, SimpleExponentialSmoothing};
+use crate::models::inspect::{Explanation, Inspectable, MstlExplanation};
 use crate::models::{validate_series_complete, Forecaster};
 use crate::seasonality::{MSTLResult, MSTL};
 use crate::utils::ols::OLSResult;
@@ -683,6 +684,39 @@ impl Forecaster for MSTLForecaster {
             .collect();
 
         Ok(Forecast::from_values(combined))
+    }
+}
+
+impl Inspectable for MSTLForecaster {
+    fn explanation(&self) -> Result<Explanation> {
+        let decomposition =
+            self.decomposition
+                .as_ref()
+                .ok_or_else(|| ForecastError::FitRequired {
+                    model: Some("MSTLForecaster".to_string()),
+                })?;
+        let fitted = self
+            .fitted
+            .clone()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("MSTLForecaster".to_string()),
+            })?;
+        let residuals = self
+            .residuals
+            .clone()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("MSTLForecaster".to_string()),
+            })?;
+        let seasonal_component = self.seasonal_sum.clone().unwrap_or_default();
+
+        Ok(Explanation::Mstl(MstlExplanation {
+            seasonal_periods: self.seasonal_periods.clone(),
+            iterations: self.mstl_iterations,
+            fitted_values: fitted,
+            trend_component: decomposition.trend.clone(),
+            seasonal_component,
+            residuals,
+        }))
     }
 }
 

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -3560,6 +3560,35 @@ mod ols_impl {
         }
     }
 
+    impl crate::models::inspect::Inspectable for RegressionForecaster {
+        fn explanation(&self) -> Result<crate::models::inspect::Explanation> {
+            use crate::models::inspect::{Explanation, RegressionExplanation};
+
+            let state = self.state.as_ref().ok_or(ForecastError::FitRequired {
+                model: Some("RegressionForecaster".to_string()),
+            })?;
+
+            let result = state.model.result();
+            let feature_names = state.features.feature_names(&state.exog_names);
+
+            let n_coef = result.coefficients.nrows();
+            let mut coefficients = Vec::with_capacity(n_coef);
+            for i in 0..n_coef {
+                coefficients.push(result.coefficients[i]);
+            }
+
+            Ok(Explanation::Regression(RegressionExplanation {
+                feature_names,
+                coefficients,
+                intercept: result.intercept.unwrap_or(0.0),
+                r_squared: result.r_squared,
+                backend: self.backend.name().to_string(),
+                fitted_values: state.fitted_values.clone(),
+                residuals: state.residuals.clone(),
+            }))
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -3578,6 +3607,34 @@ mod ols_impl {
                 .map(|i| 2.0 * i as f64 + 10.0 + 0.01 * (i as f64 * 0.7).sin())
                 .collect();
             TimeSeries::univariate(make_timestamps(n), values).unwrap()
+        }
+
+        #[test]
+        fn inspectable_linear_trend_returns_regression_explanation() {
+            use crate::models::inspect::{Explanation, Inspectable};
+
+            let ts = make_linear_ts(40);
+            let mut model = RegressionForecaster::linear_trend();
+            assert!(
+                matches!(model.explanation(), Err(ForecastError::FitRequired { .. })),
+                "explanation() before fit must return FitRequired"
+            );
+
+            model.fit(&ts).unwrap();
+            let Explanation::Regression(e) = model.explanation().unwrap() else {
+                panic!("expected Explanation::Regression");
+            };
+
+            assert_eq!(e.backend, "OLS");
+            assert_eq!(e.coefficients.len(), e.feature_names.len());
+            assert!(e.feature_names.iter().any(|n| n == "__trend"));
+            assert_eq!(e.fitted_values.len(), 40);
+            assert_eq!(e.residuals.len(), 40);
+            // Linear-trend OLS on a nearly-linear series should fit R² ≈ 1.
+            assert!(e.r_squared > 0.99, "R² unexpectedly low: {}", e.r_squared);
+            // The trend slope coefficient should recover ≈ 2.0.
+            let trend_idx = e.feature_names.iter().position(|n| n == "__trend").unwrap();
+            assert_relative_eq!(e.coefficients[trend_idx], 2.0, epsilon = 0.05);
         }
 
         #[test]

--- a/src/models/tbats/auto.rs
+++ b/src/models/tbats/auto.rs
@@ -8,6 +8,7 @@
 
 use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
+use crate::models::inspect::{Explanation, Inspectable, TbatsExplanation};
 use crate::models::tbats::TBATS;
 use crate::models::{validate_series_complete, Forecaster};
 
@@ -384,6 +385,28 @@ impl Forecaster for AutoTBATS {
 
     fn name(&self) -> &str {
         "AutoTBATS"
+    }
+}
+
+impl Inspectable for AutoTBATS {
+    fn explanation(&self) -> Result<Explanation> {
+        let best = self
+            .best_model
+            .as_ref()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoTBATS".to_string()),
+            })?;
+        let fitted_values = best.fitted_values().map(|v| v.to_vec()).unwrap_or_default();
+        let residuals = best.residuals().map(|v| v.to_vec()).unwrap_or_default();
+
+        Ok(Explanation::Tbats(TbatsExplanation {
+            seasonal_periods: self.seasonal_periods.clone(),
+            box_cox_lambda: best.lambda(),
+            selected_config: self.selected_config.clone().unwrap_or_default(),
+            aic: self.best_aic,
+            fitted_values,
+            residuals,
+        }))
     }
 }
 

--- a/src/models/theta/auto.rs
+++ b/src/models/theta/auto.rs
@@ -5,6 +5,7 @@
 
 use crate::core::{Forecast, TimeSeries};
 use crate::error::{ForecastError, Result};
+use crate::models::inspect::{Explanation, Inspectable, ThetaExplanation};
 use crate::models::theta::{DecompositionType, DynamicTheta, OptimizedTheta, Theta};
 use crate::models::{validate_series_complete, Forecaster};
 use crate::utils::ols::OLSResult;
@@ -432,6 +433,57 @@ impl Forecaster for AutoTheta {
                 m.predict_with_exog_intervals(horizon, future_regressors, level)
             }
         }
+    }
+}
+
+impl Inspectable for AutoTheta {
+    fn explanation(&self) -> Result<Explanation> {
+        let model = self
+            .fitted_model
+            .as_ref()
+            .ok_or_else(|| ForecastError::FitRequired {
+                model: Some("AutoTheta".to_string()),
+            })?;
+
+        let (variant, theta, alpha, fitted_values, residuals) = match model {
+            FittedModel::STM(m) => (
+                "STM".to_string(),
+                m.theta(),
+                m.alpha(),
+                m.fitted_values().map(|v| v.to_vec()).unwrap_or_default(),
+                m.residuals().map(|v| v.to_vec()).unwrap_or_default(),
+            ),
+            FittedModel::OTM(m) => (
+                "OTM".to_string(),
+                m.theta().unwrap_or(2.0),
+                m.alpha(),
+                m.fitted_values().map(|v| v.to_vec()).unwrap_or_default(),
+                m.residuals().map(|v| v.to_vec()).unwrap_or_default(),
+            ),
+            FittedModel::DSTM(m) => (
+                "DSTM".to_string(),
+                m.theta(),
+                Some(m.alpha()),
+                m.fitted_values().map(|v| v.to_vec()).unwrap_or_default(),
+                m.residuals().map(|v| v.to_vec()).unwrap_or_default(),
+            ),
+            FittedModel::DOTM(m) => (
+                "DOTM".to_string(),
+                m.theta(),
+                Some(m.alpha()),
+                m.fitted_values().map(|v| v.to_vec()).unwrap_or_default(),
+                m.residuals().map(|v| v.to_vec()).unwrap_or_default(),
+            ),
+        };
+
+        Ok(Explanation::Theta(ThetaExplanation {
+            variant,
+            theta,
+            alpha,
+            seasonal_period: self.seasonal_period,
+            fitted_values,
+            residuals,
+        }))
     }
 }
 

--- a/tests/issue_107_inspectable_conformance.rs
+++ b/tests/issue_107_inspectable_conformance.rs
@@ -1,0 +1,268 @@
+//! Issue #107 cross-cutting Inspectable conformance test.
+//!
+//! Exercises the `Inspectable` trait + `Explanation` enum across the
+//! seven model families that opted in. Each model is fit on a synthetic
+//! seasonal series and must:
+//!
+//! 1. Return `Err(FitRequired)` from `explanation()` before fit.
+//! 2. Return the *matching* `Explanation` variant after fit
+//!    (`Explanation::Ets` for ETS, `Explanation::Arima` for ARIMA, …).
+//! 3. Populate the universal spine: `fitted_values` non-empty,
+//!    `residuals` length matching, all scalar fields finite.
+//! 4. Round-trip through `serde_json` losslessly (gated on the
+//!    `serde` feature).
+//! 5. Be usable as `Box<dyn Inspectable>` (object-safety check).
+//!
+//! This is the safety net for the trait contract: if any model
+//! regresses on the surface, the suite fails before downstream callers
+//! pick it up.
+
+use anofox_forecast::core::TimeSeries;
+use anofox_forecast::models::arima::AutoARIMA;
+use anofox_forecast::models::exponential::AutoETS;
+use anofox_forecast::models::theta::AutoTheta;
+use anofox_forecast::models::{
+    AutoTBATS, Explanation, Forecaster, Inspectable, MSTLForecaster, MFLES,
+};
+
+use chrono::{Duration, TimeZone, Utc};
+
+fn make_seasonal_series(n: usize, period: usize) -> TimeSeries {
+    let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let timestamps: Vec<_> = (0..n).map(|i| base + Duration::hours(i as i64)).collect();
+    let values: Vec<f64> = (0..n)
+        .map(|i| {
+            let trend = 50.0 + 0.5 * i as f64;
+            let seasonal =
+                10.0 * (2.0 * std::f64::consts::PI * (i % period) as f64 / period as f64).sin();
+            let noise = ((i * 17) % 7) as f64 * 0.1 - 0.3;
+            trend + seasonal + noise
+        })
+        .collect();
+    TimeSeries::univariate(timestamps, values).unwrap()
+}
+
+fn assert_finite_scalars(label: &str, e: &Explanation) {
+    // Walk the variant and verify residual/fitted have matching cardinality
+    // and the headline scalars are finite (NaN is OK only where the variant
+    // documents it as optional).
+    match e {
+        Explanation::Regression(r) => {
+            assert_eq!(
+                r.coefficients.len(),
+                r.feature_names.len(),
+                "{label}: coefficients/feature_names length mismatch"
+            );
+            assert!(r.r_squared.is_finite(), "{label}: r_squared not finite");
+            assert!(r.intercept.is_finite(), "{label}: intercept not finite");
+            assert!(!r.backend.is_empty(), "{label}: backend empty");
+        }
+        Explanation::Ets(e) => {
+            assert!(!e.spec.is_empty(), "{label}: ETS spec empty");
+            assert!(e.alpha.is_finite(), "{label}: alpha not finite");
+        }
+        Explanation::Arima(a) => {
+            assert!(a.aic.is_finite(), "{label}: aic not finite");
+            assert!(a.bic.is_finite(), "{label}: bic not finite");
+        }
+        Explanation::Mfles(m) => {
+            assert!(m.max_rounds > 0, "{label}: max_rounds should be positive");
+        }
+        Explanation::Theta(t) => {
+            assert!(!t.variant.is_empty(), "{label}: theta variant empty");
+            assert!(t.theta.is_finite(), "{label}: theta not finite");
+        }
+        Explanation::Tbats(t) => {
+            assert!(
+                !t.seasonal_periods.is_empty(),
+                "{label}: no seasonal_periods"
+            );
+            assert!(t.aic.is_finite(), "{label}: aic not finite");
+        }
+        Explanation::Mstl(m) => {
+            assert!(
+                !m.seasonal_periods.is_empty(),
+                "{label}: no seasonal_periods"
+            );
+            assert!(m.iterations > 0, "{label}: iterations must be > 0");
+        }
+    }
+}
+
+fn assert_spine(label: &str, e: &Explanation) {
+    let (fitted, residuals) = match e {
+        Explanation::Regression(r) => (&r.fitted_values, &r.residuals),
+        Explanation::Ets(x) => (&x.fitted_values, &x.residuals),
+        Explanation::Arima(x) => (&x.fitted_values, &x.residuals),
+        Explanation::Mfles(x) => (&x.fitted_values, &x.residuals),
+        Explanation::Theta(x) => (&x.fitted_values, &x.residuals),
+        Explanation::Tbats(x) => (&x.fitted_values, &x.residuals),
+        Explanation::Mstl(x) => (&x.fitted_values, &x.residuals),
+    };
+    assert!(!fitted.is_empty(), "{label}: fitted_values empty");
+    assert_eq!(
+        fitted.len(),
+        residuals.len(),
+        "{label}: fitted/residuals length mismatch"
+    );
+}
+
+#[test]
+fn mstl_inspectable_contract() {
+    let ts = make_seasonal_series(200, 24);
+    let mut model = MSTLForecaster::new(vec![24]);
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Mstl(_)), "expected Mstl variant");
+    assert_finite_scalars("MSTLForecaster", &e);
+    assert_spine("MSTLForecaster", &e);
+}
+
+#[test]
+fn mfles_inspectable_contract() {
+    let ts = make_seasonal_series(120, 12);
+    let mut model = MFLES::new(vec![12]);
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Mfles(_)), "expected Mfles variant");
+    assert_finite_scalars("MFLES", &e);
+    assert_spine("MFLES", &e);
+}
+
+#[test]
+fn auto_arima_inspectable_contract() {
+    let ts = make_seasonal_series(80, 12);
+    let mut model = AutoARIMA::new();
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Arima(_)), "expected Arima variant");
+    assert_finite_scalars("AutoARIMA", &e);
+    assert_spine("AutoARIMA", &e);
+}
+
+#[test]
+fn auto_ets_inspectable_contract() {
+    let ts = make_seasonal_series(60, 12);
+    let mut model = AutoETS::new();
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Ets(_)), "expected Ets variant");
+    assert_finite_scalars("AutoETS", &e);
+    assert_spine("AutoETS", &e);
+}
+
+#[test]
+fn auto_theta_inspectable_contract() {
+    let ts = make_seasonal_series(60, 12);
+    let mut model = AutoTheta::new();
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Theta(_)), "expected Theta variant");
+    assert_finite_scalars("AutoTheta", &e);
+    assert_spine("AutoTheta", &e);
+}
+
+#[test]
+fn auto_tbats_inspectable_contract() {
+    let ts = make_seasonal_series(120, 12);
+    let mut model = AutoTBATS::new(vec![12]);
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(matches!(e, Explanation::Tbats(_)), "expected Tbats variant");
+    assert_finite_scalars("AutoTBATS", &e);
+    assert_spine("AutoTBATS", &e);
+}
+
+#[cfg(feature = "postprocess")]
+#[test]
+fn regression_forecaster_inspectable_contract() {
+    use anofox_forecast::models::regression::RegressionForecaster;
+
+    // Use a simple linear-trend series.
+    let n = 60;
+    let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let timestamps: Vec<_> = (0..n).map(|i| base + Duration::days(i as i64)).collect();
+    let values: Vec<f64> = (0..n).map(|i| 5.0 + 2.0 * i as f64).collect();
+    let ts = TimeSeries::univariate(timestamps, values).unwrap();
+
+    let mut model = RegressionForecaster::linear_trend();
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    assert!(
+        matches!(e, Explanation::Regression(_)),
+        "expected Regression variant"
+    );
+    assert_finite_scalars("RegressionForecaster", &e);
+    assert_spine("RegressionForecaster", &e);
+}
+
+#[test]
+fn inspectable_is_object_safe() {
+    // The trait must be usable behind Box<dyn _> because Explanation
+    // is fully owned. This compile-and-call test will fail to link
+    // (or panic at fit) if object-safety regresses.
+    let ts = make_seasonal_series(60, 12);
+    let mut ets = AutoETS::new();
+    ets.fit(&ts).unwrap();
+    let boxed: Box<dyn Inspectable> = Box::new(ets);
+    let e = boxed.explanation().unwrap();
+    assert!(matches!(e, Explanation::Ets(_)));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn explanation_serializes_to_json_for_every_variant() {
+    // Verify each Inspectable model produces an Explanation that can be
+    // serialized to JSON. We do NOT assert round-trip equality here for
+    // two reasons:
+    //   1. Some fitted models leave `NaN` in `fitted_values` (warm-up
+    //      rows on AutoARIMA, etc.) which serde_json renders as `null`
+    //      — and `null` is not deserialisable back into `f64`.
+    //   2. JSON's f64 formatter is not bit-exact and can lose one ULP.
+    // The bit-exact / lossless round-trip is exercised by the unit
+    // tests in src/models/inspect.rs on hand-crafted finite payloads.
+    // Here we just guarantee serialization works end-to-end on real
+    // fit outputs.
+    fn check(label: &str, e: &Explanation) {
+        let json = serde_json::to_string(e).unwrap();
+        assert!(!json.is_empty(), "{label}: JSON serialization empty");
+        assert!(
+            json.starts_with('{'),
+            "{label}: expected JSON object, got {}",
+            &json[..json.len().min(40)]
+        );
+    }
+
+    let ts = make_seasonal_series(120, 12);
+
+    let mut ets = AutoETS::new();
+    ets.fit(&ts).unwrap();
+    check("AutoETS", &ets.explanation().unwrap());
+
+    let mut mstl = MSTLForecaster::new(vec![12]);
+    mstl.fit(&ts).unwrap();
+    check("MSTLForecaster", &mstl.explanation().unwrap());
+
+    let mut theta = AutoTheta::new();
+    theta.fit(&ts).unwrap();
+    check("AutoTheta", &theta.explanation().unwrap());
+
+    let mut arima = AutoARIMA::new();
+    arima.fit(&ts).unwrap();
+    check("AutoARIMA", &arima.explanation().unwrap());
+
+    let mut mfles = MFLES::new(vec![12]);
+    mfles.fit(&ts).unwrap();
+    check("MFLES", &mfles.explanation().unwrap());
+
+    let mut tbats = AutoTBATS::new(vec![12]);
+    tbats.fit(&ts).unwrap();
+    check("AutoTBATS", &tbats.explanation().unwrap());
+}


### PR DESCRIPTION
## Summary

Implements **issue #107** — a typed sibling to the existing `Explainable` (forecast-decomposition) trait. Where `Explainable` decomposes a *forecast*, the new **`Inspectable`** trait packages the *fit*: a per-model snapshot of internal state + interpretable parameters as a single `Explanation` enum value that consumers can serialise, cache, and surface to UIs.

This is stacked on **PR #108** (issue #106 — `Decomposable` accessors); merge that first.

## Design

- **`Inspectable::explanation(&self) -> Result<Explanation>`** — object-safe (no borrows), so `Box<dyn Inspectable>` works.
- **`Explanation`** — owned enum with seven variants (`Regression`, `Ets`, `Arima`, `Mfles`, `Theta`, `Tbats`, `Mstl`). Each carries the universal spine (`fitted_values`, `residuals`) plus model-specific scalars and structural components. `Clone + PartialEq + Default` and, behind the `serde` feature, `Serialize + Deserialize`.
- **Naming**: chose `Inspectable` (per user's "Option 1") to avoid colliding with the pre-existing forecast-decomposition `Explainable` trait at `src/models/explain.rs`.

## Coverage

| Model family | Variant |
| --- | --- |
| `RegressionForecaster` | `Explanation::Regression` |
| `MSTLForecaster` | `Explanation::Mstl` |
| `MFLES` | `Explanation::Mfles` |
| `AutoARIMA` | `Explanation::Arima` |
| `AutoETS` | `Explanation::Ets` |
| `AutoTheta` | `Explanation::Theta` |
| `AutoTBATS` | `Explanation::Tbats` |

Baselines (`Naive`, `RandomWalkDrift`, …) and the intermittent-demand family don't have interpretable structure worth packaging, so they don't opt in.

## Phases (matches commit history)

- **Phase 0** — trait + enum + 7 payload structs + 3 unit tests
- **Phase 1** — `RegressionForecaster::explanation()` + unit test
- **Phase 2** — six auto-tuned forecasters
- **Phase 3** — cross-cutting conformance test (`tests/issue_107_inspectable_conformance.rs`)

## Test plan

- [x] `cargo test --lib` — 2893 passed (+1 new), 1 ignored
- [x] `cargo test --test issue_107_inspectable_conformance` — 8 passed (default features)
- [x] `cargo test --test issue_107_inspectable_conformance --features serde` — 9 passed
- [x] `cargo test --test issue_106_decomposable_conformance` — 12 passed (no regression in stacked PR)
- [x] `cargo clippy --lib --tests --features serde` — no new warnings on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)