### PR TITLE
Release v0.8.0: Decomposable accessors + Inspectable trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-10
+
+### Added
+
+- **`Forecaster` decomposition + training-state accessors** (closes #106) — three new methods on the `Forecaster` trait expose primitive fit state previously only available through model-specific accessors. All three have default impls so existing implementors continue to compile.
+  - `trend_component() -> Result<&[f64]>` — per-row trend (where defined; `Err(InvalidParameter)` otherwise).
+  - `seasonal_component() -> Result<&[f64]>` — per-row seasonal contribution (sum of components for multi-seasonal models like MSTL).
+  - `residual_component() -> Result<&[f64]>` — per-row residual; default delegates to `residuals()`. MSTL overrides to return the STL remainder.
+  - `training_values() -> Result<&[f64]>` — the values the model was fit on.
+  - `training_regressors() -> Option<&HashMap<String, Vec<f64>>>` — exogenous regressors retained at fit time.
+  - Implemented natively on 11 auto-tuned models: `MSTLForecaster`, `MFLES`, `AutoARIMA`, `SimpleExponentialSmoothing`, `HoltLinearTrend`, `HoltWinters`, `SeasonalES`, `AutoETS`, `AutoTheta`, `DynamicTheta`, `OptimizedTheta`, `AutoTBATS`. `predict_with_exog` is also routed through a residual-Ridge shim (`src/utils/exog_shim.rs`, Cholesky-solved closed form) so models that don't natively support regressors can still accept them at fit time.
+  - Cross-cutting conformance test at `tests/issue_106_decomposable_conformance.rs` validates the contract (trend + seasonal + residual ≈ training, with documented exceptions for AutoARIMA differencing).
+
+- **`Inspectable` trait + `Explanation` enum** (closes #107) — typed sibling to the existing `Explainable` (forecast-decomposition) trait. Where `Explainable` decomposes a *forecast*, `Inspectable` packages the *fit*: a per-model snapshot of internal state and interpretable parameters.
+  - `Inspectable::explanation(&self) -> Result<Explanation>` — object-safe, so `Box<dyn Inspectable>` works.
+  - `Explanation` is an owned enum with seven variants: `Regression`, `Ets`, `Arima`, `Mfles`, `Theta`, `Tbats`, `Mstl`. Each carries the universal spine (`fitted_values`, `residuals`) plus model-specific scalars (e.g. ETS spec + α/β/γ/φ, ARIMA order + AIC/BIC + coefficients, Regression R² + feature names + coefficients + intercept, TBATS Box-Cox λ + selected config).
+  - All variants are `Clone + PartialEq + Default`. Behind the `serde` feature: `Serialize + Deserialize` for caching, transport, and UI surfacing.
+  - Implemented on `RegressionForecaster`, `MSTLForecaster`, `MFLES`, `AutoARIMA`, `AutoETS`, `AutoTheta`, `AutoTBATS`. Returns `Err(FitRequired)` before fit.
+  - Cross-cutting conformance test at `tests/issue_107_inspectable_conformance.rs` covers per-model variant matching, spine invariants, object-safety, and serde-JSON serialization across every variant.
+
 ## [0.7.6] - 2026-05-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.7.6"
+version = "0.8.0"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.7.6"
+anofox-forecast = "0.8.0"
 ```
 
 ### Optional Features
@@ -266,19 +266,19 @@ anofox-forecast = "0.7.6"
 ```toml
 [dependencies]
 # Forecastability analysis (MI, GCMI, distance correlation, fingerprint)
-anofox-forecast = { version = "0.7", features = ["forecastability"] }
+anofox-forecast = { version = "0.8", features = ["forecastability"] }
 
 # Forecastability + parallel (60× faster with rayon)
-anofox-forecast = { version = "0.7", features = ["forecastability", "parallel"] }
+anofox-forecast = { version = "0.8", features = ["forecastability", "parallel"] }
 
 # Parallel AutoARIMA (4-8x speedup via rayon, opt-in for embedding contexts like DuckDB)
-anofox-forecast = { version = "0.7", features = ["parallel"] }
+anofox-forecast = { version = "0.8", features = ["parallel"] }
 
 # Model serialization (save/load to JSON)
-anofox-forecast = { version = "0.7", features = ["serde"] }
+anofox-forecast = { version = "0.8", features = ["serde"] }
 
 # Probabilistic postprocessing (conformal, IDR, QRA — enabled by default)
-anofox-forecast = { version = "0.7", default-features = false }  # to disable
+anofox-forecast = { version = "0.8", default-features = false }  # to disable
 ```
 
 | Feature | Default | Description |

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.7.6"
+version = "0.8.0"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Lock-step minor bump **0.7.6 → 0.8.0** wrapping the two new trait surfaces that landed this week.

### Issue #106 — Decomposable / training-state accessors (PR #108)

Five new methods on the `Forecaster` trait expose primitive fit state previously only available through model-specific accessors. All have default impls so existing implementors continue to compile.

- `trend_component()`, `seasonal_component()`, `residual_component()`, `training_values()`, `training_regressors()`
- Implemented natively on 11 auto-tuned models
- `predict_with_exog` routes through a residual-Ridge shim for non-native models
- Conformance: `tests/issue_106_decomposable_conformance.rs` (12 tests)

### Issue #107 — Inspectable trait + Explanation enum (PR #109)

Typed sibling to the existing `Explainable` (forecast-decomposition) trait — packages each model's *fit state* as an owned, serialisable `Explanation` enum.

- 7 variants: `Regression`, `Ets`, `Arima`, `Mfles`, `Theta`, `Tbats`, `Mstl`
- Object-safe (`Box<dyn Inspectable>` works)
- `Clone + PartialEq + Default`; `Serialize + Deserialize` under the `serde` feature
- Conformance: `tests/issue_107_inspectable_conformance.rs` (9 tests)

## Version bumps

- `Cargo.toml`: 0.7.6 → 0.8.0
- `crates/anofox-forecast-js/Cargo.toml`: 0.7.6 → 0.8.0
- `crates/anofox-forecast-js/package.json`: 0.7.6 → 0.8.0
- `js/package.json`: 0.7.6 → 0.8.0
- `Cargo.lock`: regenerated
- `README.md`: install snippet and feature-flag examples updated
- `CHANGELOG.md`: new `[0.8.0]` entry

## Semver

Minor bump — API additions only, no breaking changes. New trait methods have default impls.

## Test plan

- [x] `cargo test --lib --features serde` — 2893 passed
- [x] `tests/issue_106_decomposable_conformance.rs` — 12 passed
- [x] `tests/issue_107_inspectable_conformance.rs` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)