### PR TITLE
Release v0.8.2: fix #113 (exog_features-claimed column exclusion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-06-15
+
+### Fixed
+
+- **`RegressionForecaster`: columns claimed by `exog_features` are now excluded from the raw exog block** (closes #113). Previously, declaring a column via `with_categorical("is_chp", …)` while leaving `.exog()` enabled inserted that column both as a raw numeric column *and* as its one-hot dummies, producing perfect collinearity and a singular design matrix that blew OLS up. The fix excludes any column referenced by an `exog_features` spec (Categorical / Lag / Rolling / Polynomial / Interaction) from the raw exog name list — letting callers declare *some* regressors categorical and others numeric, without the all-or-nothing `.no_exog()` workaround.
+
+### Changed
+
+- **`predict_with_exog` validation now covers all spec-claimed columns**. Columns referenced by `exog_features` entries (which the encoder reads via `future_at` at predict time) are now required in `future_regressors`. A missing claimed column surfaces a clear `InvalidParameter` error instead of silently producing zeros.
+
+### Breaking (narrow)
+
+- A caller who deliberately relied on `.exog().with_exog_lags("foo", &[1])` to produce both raw `foo` *and* `foo_lag1` columns no longer gets the raw column. The motivating Categorical case is the strictly-correct fix; for the lag/rolling cases this is a behaviour change. Workaround: declare derived features on a different column name, or accept the loss of raw column.
+
 ## [0.8.1] - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.8.1"
+anofox-forecast = "0.8.2"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -2425,9 +2425,25 @@ mod ols_impl {
 
             let n_train = n - offset;
 
-            // Collect exogenous regressor names (sorted for determinism)
+            // Collect exogenous regressor names (sorted for determinism).
+            // Columns already claimed by an exog_features spec
+            // (Categorical / Lag / Rolling / Polynomial / Interaction)
+            // are excluded from the raw exog block — they're already
+            // represented downstream by the spec's derived columns, so
+            // including them as raw would cause collinearity (clearest
+            // case: Categorical OneHot + raw == singular). Closes #113.
             let exog_names = if self.use_exog && series.has_regressors() {
-                let mut names: Vec<String> = series.all_regressors().keys().cloned().collect();
+                let claimed: std::collections::HashSet<&str> = self
+                    .exog_features
+                    .iter()
+                    .flat_map(|s| s.referenced_cols())
+                    .collect();
+                let mut names: Vec<String> = series
+                    .all_regressors()
+                    .keys()
+                    .filter(|k| !claimed.contains(k.as_str()))
+                    .cloned()
+                    .collect();
                 names.sort();
                 names
             } else {
@@ -3706,13 +3722,26 @@ mod ols_impl {
                 return Ok(Forecast::new());
             }
 
-            // Validate that all required regressors are provided
-            for name in &state.exog_names {
-                match future_regressors.get(name) {
+            // Validate that all required regressors are provided —
+            // both raw exog columns (state.exog_names) AND columns
+            // claimed by exog_features specs (Categorical / Lag /
+            // Rolling / Polynomial / Interaction). The two are
+            // disjoint after the #113 fix; we union them here so a
+            // claimed column being absent still surfaces an error
+            // instead of silently producing zeros.
+            let mut required: std::collections::BTreeSet<&str> =
+                state.exog_names.iter().map(|s| s.as_str()).collect();
+            for spec in &state.features.exog_features {
+                for col in spec.referenced_cols() {
+                    required.insert(col);
+                }
+            }
+            for name in &required {
+                match future_regressors.get(*name) {
                     None => {
                         return Err(ForecastError::InvalidParameter(format!(
                             "Missing future regressor '{}'. Required: {:?}",
-                            name, state.exog_names
+                            name, required
                         )));
                     }
                     Some(vals) if vals.len() < horizon => {
@@ -4244,6 +4273,103 @@ mod ols_impl {
             assert_relative_eq!(preds[0], 1.0, epsilon = 1e-6);
             assert_relative_eq!(preds[1], 5.0, epsilon = 1e-6);
             assert_relative_eq!(preds[2], 9.0, epsilon = 1e-6);
+        }
+
+        #[test]
+        fn issue_113_categorical_excludes_raw_exog_for_same_column() {
+            // Before #113 fix: declaring a column via with_categorical(...)
+            // while keeping .exog() on caused the column to appear BOTH as
+            // raw numeric AND as its one-hot dummies, producing perfect
+            // collinearity. After the fix, the claimed column is excluded
+            // from the raw exog block so the design stays well-conditioned
+            // and a *different* raw regressor can still flow through.
+            let n = 60;
+            let mut cat = Vec::with_capacity(n);
+            let mut promo = Vec::with_capacity(n);
+            let mut y = Vec::with_capacity(n);
+            for i in 0..n {
+                let c = (i % 3) as i64;
+                cat.push(c as f64);
+                // independent binary regressor — bumps y by 2 when on
+                let p = ((i / 4) % 2) as i64;
+                promo.push(p as f64);
+                y.push(
+                    match c {
+                        0 => 1.0,
+                        1 => 5.0,
+                        2 => 9.0,
+                        _ => unreachable!(),
+                    } + 2.0 * p as f64,
+                );
+            }
+            let cal = CalendarAnnotations::new()
+                .with_regressor("is_chp".to_string(), cat)
+                .with_regressor("promo".to_string(), promo);
+            let ts = TimeSeriesBuilder::new()
+                .timestamps(make_timestamps(n))
+                .values(y)
+                .calendar(cal)
+                .build()
+                .unwrap();
+
+            // .exog() ON, plus .with_categorical("is_chp", …)
+            // — the pre-fix path would produce a singular X.
+            let mut model = RegressionForecaster::ols(
+                RegressionFeatures::new()
+                    .no_trend()
+                    .with_categorical(
+                        "is_chp",
+                        vec![0, 1, 2],
+                        CategoricalStrategy::OneHot { drop_first: true },
+                    )
+                    .unwrap(),
+            );
+            model.fit(&ts).unwrap();
+
+            // Feature-name sanity: raw `promo` present, raw `is_chp` absent,
+            // is_chp dummies present.
+            let names = model.features().feature_names(&["promo".to_string()]);
+            assert!(
+                names.contains(&"promo".to_string()),
+                "expected raw 'promo' in feature names, got {:?}",
+                names,
+            );
+            assert!(
+                !names.contains(&"is_chp".to_string()),
+                "raw 'is_chp' must be excluded (claimed by categorical), got {:?}",
+                names,
+            );
+            assert!(
+                names
+                    .iter()
+                    .any(|n| n == "is_chp_eq_1" || n == "is_chp_eq_2"),
+                "expected at least one is_chp dummy in feature names, got {:?}",
+                names,
+            );
+
+            // Forecast: should recover the four expected combos
+            //   (cat, promo) → y: (0,0)→1, (1,1)→7, (2,0)→9, (0,1)→3
+            let mut fr = HashMap::new();
+            fr.insert("is_chp".to_string(), vec![0.0, 1.0, 2.0, 0.0]);
+            fr.insert("promo".to_string(), vec![0.0, 1.0, 0.0, 1.0]);
+            let forecast = model.predict_with_exog(4, &fr).unwrap();
+            let preds = forecast.primary();
+            assert_relative_eq!(preds[0], 1.0, epsilon = 1e-4);
+            assert_relative_eq!(preds[1], 7.0, epsilon = 1e-4);
+            assert_relative_eq!(preds[2], 9.0, epsilon = 1e-4);
+            assert_relative_eq!(preds[3], 3.0, epsilon = 1e-4);
+
+            // Validation: missing a claimed column at predict time must
+            // surface an error (regression test for the extended
+            // predict_with_exog validation in #113).
+            let mut fr_missing = HashMap::new();
+            fr_missing.insert("promo".to_string(), vec![0.0, 1.0, 0.0, 1.0]);
+            // 'is_chp' deliberately absent
+            let err = model.predict_with_exog(4, &fr_missing);
+            assert!(
+                err.is_err(),
+                "predict_with_exog should error when a claimed column ('is_chp') is missing from future regressors",
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Patch release **0.8.1 → 0.8.2** fixing **#113**: `RegressionForecaster` was inserting a categorical column both as raw numeric *and* as its one-hot dummies, producing a singular design matrix.

## The fix

`build_matrices` now filters the raw exog name list to exclude any column referenced by an `exog_features` entry (Categorical / Lag / Rolling / Polynomial / Interaction). `predict_with_exog` validation extends to the union of `state.exog_names` and exog_features-referenced columns so a missing claimed column surfaces a clear `InvalidParameter` error instead of silently zeroing out the encoder input.

Net effect for the motivating case:

```rust
RegressionFeatures::new()
    .exog()                                                    // promo, is_chp from CalendarAnnotations
    .with_categorical("is_chp", vec![0, 1, 2],
        CategoricalStrategy::OneHot { drop_first: true })      // is_chp_eq_1, is_chp_eq_2
// → before #113: raw is_chp + is_chp_eq_1 + is_chp_eq_2 → collinear → OLS blows up.
// → after #113:  promo + is_chp_eq_1 + is_chp_eq_2.
```

## Behaviour change (narrow)

A caller who deliberately wanted `.exog().with_exog_lags("foo", &[1])` to give them both raw `foo` *and* `foo_lag1` no longer gets the raw column. For Categorical this is strictly correct; for Lag/Rolling/Polynomial/Interaction it's a deliberate trade — those derived features are already collinear-free with the raw column, but the user has opted into a structured representation by declaring the spec. Workaround: declare the derived feature on a different column name. Documented in the changelog under "Breaking (narrow)".

## Version bumps

- `Cargo.toml`: 0.8.1 → 0.8.2
- `crates/anofox-forecast-js/Cargo.toml`: 0.8.1 → 0.8.2
- `crates/anofox-forecast-js/package.json`: 0.8.1 → 0.8.2
- `js/package.json`: 0.8.1 → 0.8.2
- `Cargo.lock`: regenerated
- `README.md`: install snippet
- `CHANGELOG.md`: new `[0.8.2]` entry

## Test plan

- [x] `cargo test --lib --features serde` — 2900 passed (+1 since 0.8.1)
- [x] New regression test `issue_113_categorical_excludes_raw_exog_for_same_column` covers: feature-name set (raw `is_chp` absent, raw `promo` present, dummies present), recovery of 4 (cat, promo) combos, and predict-time validation rejecting missing claimed columns.
- [x] All integration suites still green (including #106 / #107 conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)