### PR TITLE
Release v0.8.3: fix #115 (WlsLogisticRidge standard errors on original scale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-06-16
+
+### Fixed
+
+- **`WlsLogisticRidge`: standard errors are now computed on the original-scale design** (closes #115). The v0.8.1 implementation built `RegressionResult` by cloning the augmented OLS fit's result and overwriting intercept / fitted / residuals / R² on the original scale — but never replaced `std_errors`, so the SE values surfaced via `RegressionExplanation` came from the centred + √W-scaled + Tikhonov-augmented design (wrong units, silently wrong/empty for downstream consumers). The fix recomputes `Cov(β̂) = σ̂² · (Xfullᵀ W Xfull + λI_β)⁻¹` inline using faer Cholesky, populating `result.std_errors` and `result.intercept_std_error` so the Inspectable surface returns finite, positive SEs aligned with the coefficients.
+
 ## [0.8.2] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.8.2"
+anofox-forecast = "0.8.3"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -1235,12 +1235,77 @@ mod ols_impl {
                     let y_mean: f64 = (0..n).map(|i| y[i]).sum::<f64>() / n as f64;
                     let tss: f64 = (0..n).map(|i| (y[i] - y_mean).powi(2)).sum();
                     let r_squared = if tss > 0.0 { 1.0 - rss / tss } else { 0.0 };
+
+                    // Compute standard errors on the original-scale design.
+                    // The augmented OLS that produced β was fitted on a
+                    // centred + √W-scaled + Tikhonov-augmented design, so
+                    // its result.std_errors are in the wrong units and
+                    // must NOT be propagated. Instead, populate from the
+                    // weighted covariance
+                    //   Cov(β̂) = σ̂² · (Xfullᵀ W Xfull + λI_β)⁻¹
+                    //   σ̂² = Σ wᵢ rᵢ² / (Σ wᵢ − (p + 1))
+                    // where Xfull prepends the intercept column and
+                    // λI_β has 0 on the intercept diagonal (intercept is
+                    // unpenalised). This is the "plain weighted Ridge"
+                    // form from issue #115 — gives correct SEs at λ = 0
+                    // and a numerically-stable approximation for λ > 0.
+                    let p_full = p + 1;
+                    let mut xtwx: Mat<f64> = Mat::zeros(p_full, p_full);
+                    let mut sum_w_rsq = 0.0;
+                    for i in 0..n {
+                        let wi = w[i];
+                        sum_w_rsq += wi * residuals[i] * residuals[i];
+                        xtwx[(0, 0)] += wi;
+                        for j in 0..p {
+                            let wij = wi * x[(i, j)];
+                            xtwx[(0, j + 1)] += wij;
+                            xtwx[(j + 1, 0)] += wij;
+                            for k in 0..p {
+                                xtwx[(j + 1, k + 1)] += wij * x[(i, k)];
+                            }
+                        }
+                    }
+                    for j in 0..p {
+                        xtwx[(j + 1, j + 1)] += *lambda;
+                    }
+                    let df_eff = sum_w - p_full as f64;
+                    let sigma_sq = if df_eff > 0.0 {
+                        sum_w_rsq / df_eff
+                    } else {
+                        f64::NAN
+                    };
+                    let (std_errors_opt, intercept_se_opt) = match xtwx.llt(faer::Side::Lower) {
+                        Ok(llt) => {
+                            use faer::linalg::solvers::DenseSolveCore;
+                            let inv: Mat<f64> = llt.inverse();
+                            let mut se_coef = Col::<f64>::zeros(p);
+                            for j in 0..p {
+                                let var = sigma_sq * inv[(j + 1, j + 1)];
+                                se_coef[j] = if var.is_finite() && var >= 0.0 {
+                                    var.sqrt()
+                                } else {
+                                    f64::NAN
+                                };
+                            }
+                            let var_int = sigma_sq * inv[(0, 0)];
+                            let se_int = if var_int.is_finite() && var_int >= 0.0 {
+                                var_int.sqrt()
+                            } else {
+                                f64::NAN
+                            };
+                            (Some(se_coef), Some(se_int))
+                        }
+                        Err(_) => (None, None),
+                    };
+
                     let mut result = ols_fitted.result().clone();
                     result.intercept = Some(intercept);
                     result.fitted_values = fitted_values;
                     result.residuals = residuals;
                     result.n_observations = n;
                     result.r_squared = r_squared;
+                    result.std_errors = std_errors_opt;
+                    result.intercept_std_error = intercept_se_opt;
                     Ok(Box::new(WlsLogisticRidgeFitted { result }))
                 }
                 Self::Rls { forgetting_factor } => {
@@ -5388,6 +5453,53 @@ mod ols_impl {
                     v
                 );
             }
+        }
+
+        #[test]
+        fn wls_logistic_ridge_populates_finite_standard_errors() {
+            // Issue #115: SE on WlsLogisticRidge must come from the
+            // original-scale weighted covariance, not from the cloned
+            // augmented-fit residual. After this fix they must be
+            // finite, positive, and length-aligned with coefficients.
+            use crate::models::inspect::{Explanation, Inspectable};
+
+            let ts = make_linear_ts(50);
+            let mut model = RegressionForecaster::wls_logistic_ridge(
+                12.0,
+                1.0,
+                RegressionFeatures::new().trend().no_exog(),
+            );
+            model.fit(&ts).unwrap();
+
+            let Explanation::Regression(e) = model.explanation().unwrap() else {
+                panic!("expected Explanation::Regression");
+            };
+
+            assert_eq!(
+                e.coef_std_errors.len(),
+                e.coefficients.len(),
+                "coef_std_errors must align with coefficients (got {}, {})",
+                e.coef_std_errors.len(),
+                e.coefficients.len(),
+            );
+            assert!(
+                !e.coef_std_errors.is_empty(),
+                "coef_std_errors must be populated for WlsLogisticRidge",
+            );
+            for (i, &se) in e.coef_std_errors.iter().enumerate() {
+                assert!(se.is_finite(), "SE[{}] not finite: {}", i, se);
+                assert!(se > 0.0, "SE[{}] not positive: {}", i, se);
+            }
+            assert!(
+                e.intercept_std_error.is_finite(),
+                "intercept SE not finite: {}",
+                e.intercept_std_error,
+            );
+            assert!(
+                e.intercept_std_error > 0.0,
+                "intercept SE not positive: {}",
+                e.intercept_std_error,
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Patch release **0.8.2 → 0.8.3** fixing **#115**: `WlsLogisticRidge` was surfacing standard errors from the augmented OLS fit (centred + √W-scaled + Tikhonov-augmented design — wrong units), not the original-scale weighted covariance.

## Root cause

The v0.8.1 `WlsLogisticRidge` implementation (PR #112) cloned the augmented OLS fit's `RegressionResult` and overwrote `intercept` / `fitted_values` / `residuals` / `r_squared` / `n_observations` on the original scale — but never replaced `std_errors`. Downstream consumers reading `RegressionExplanation::coef_std_errors` got values in the wrong scale, manifesting as null or wildly inconsistent SEs in the Kärcher APO coefficient forest plot.

## The fix

After solving for the original-scale coefficients, compute SE inline from the weighted covariance:

```
Cov(β̂) = σ̂² · (Xfullᵀ W Xfull + λI_β)⁻¹
σ̂²     = Σ wᵢ rᵢ² / (Σ wᵢ − (p + 1))
```

- `Xfull` prepends the intercept column.
- `λI_β` has 0 on the intercept diagonal (intercept is unpenalised, matching how it was reconstructed analytically).
- Inverse via faer Cholesky (`xtwx.llt(faer::Side::Lower).inverse()`); `Err` leaves SE as `None`.
- Populates both `result.std_errors` and `result.intercept_std_error` so the existing `Inspectable` impl reads them correctly.

The form matches the issue's requested fix: simple `(XᵀWX + λI)⁻¹` rather than the ridge-adjusted sandwich `(XᵀWX + λI)⁻¹ XᵀWX (XᵀWX + λI)⁻¹`. The author explicitly noted the simpler form is "a big improvement over NULL"; ridge-adjusted form is a possible future refinement.

## Out of scope

Pure WLS (`wls_logistic`, `wls_decay`) goes through `anofox-regression::WlsRegressor` which already populates SE via `compute_inference`. The issue's secondary observation that WLS SEs were null for the orchestrator's heavy-feature design is probably a separate numerical-robustness issue (singular `X'WX`) — happy to follow up if a specific repro lands.

## Version bumps

- `Cargo.toml`: 0.8.2 → 0.8.3
- `crates/anofox-forecast-js/Cargo.toml`: 0.8.2 → 0.8.3
- `crates/anofox-forecast-js/package.json`: 0.8.2 → 0.8.3
- `js/package.json`: 0.8.2 → 0.8.3
- `Cargo.lock`: regenerated
- `README.md`: install snippet
- `CHANGELOG.md`: new `[0.8.3]` entry

## Test plan

- [x] `cargo test --lib --features serde` — 2901 passed (+1 since 0.8.2)
- [x] New regression test `wls_logistic_ridge_populates_finite_standard_errors` asserts SE shape + finite + positive values
- [x] All integration suites still green (including #106 / #107 conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)