### PR TITLE
Release v0.8.5: WLS silent-NaN guard (#119) + auto-penalty PiecewiseLinearTrend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-06-16
+
+### Added
+
+- **`PiecewiseLinearTrend::with_auto_penalty()`** — per-series automatic PELT penalty selection via CROPS + elbow (Haynes et al. 2017). Drop-in replacement for hand-tuning the `penalty` knob: when enabled, `fit_trend` runs `Pelt::auto_detect` over a geometric range and picks the elbow where adding one more knot stops paying for itself. Default remains `auto_penalty = false` so existing callers are unaffected.
+- **`AutoTrend`'s PiecewiseLinear candidate** now uses `.with_auto_penalty()`. Previously it always ran with `penalty = 10`, so PiecewiseLinear could lose to Quadratic on series where a different penalty would have made it the best fit. With per-series penalty selection it competes fairly in the AICc / BIC / Holdout bake-off.
+
+### Fixed
+
+- **Plain WLS backend no longer returns silent-NaN coefficients** (closes #119). On heavy-feature / small-effective-N designs (e.g. `wls_logistic` with `offset = 24` against ~20 categorical dummies on a short window), `WlsRegressor` could return a successful result whose coefficients were `NaN` — the NaN then propagated into fitted values and forecasts, which silently looked "successful" to downstream consumers and quietly dropped the method from honest backtests (orchestrator repro: 151,656 / 151,656 NaN fold rows). The `Wls` fit_to arm now walks `result.coefficients` and `result.intercept` after the solve; any non-finite entry not explained by `result.aliased` surfaces a clean `Err` pointing the caller at `wls_logistic_ridge` with λ > 0 (same recency weighting plus L2 regularisation). The legitimate pivoted-out aliased path is preserved.
+
 ## [0.8.4] - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.8.4"
+anofox-forecast = "0.8.5"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -1145,6 +1145,37 @@ mod ols_impl {
                         .weights(weights)
                         .build();
                     let fitted = model.fit(x, y).map_err(|e| format!("WLS: {}", e))?;
+                    // Issue #119: WlsRegressor can return a successful
+                    // result whose coefficients are silent NaN on heavy-
+                    // feature / small-effective-N designs (singular weighted
+                    // normal matrix). Detect that here and surface a clean
+                    // error instead of letting NaN propagate into the
+                    // forecast — silently-NaN forecasts look "successful"
+                    // to downstream consumers and quietly drop the method
+                    // from honest backtests. Aliased columns intentionally
+                    // carry NaN (pivoted-out rank-deficient directions);
+                    // those are fine.
+                    {
+                        let result = fitted.result();
+                        let coefs = &result.coefficients;
+                        for j in 0..coefs.nrows() {
+                            let aliased = result.aliased.get(j).copied().unwrap_or(false);
+                            if !aliased && !coefs[j].is_finite() {
+                                return Err(format!(
+                                    "WLS: non-finite coefficient[{}] (= {}) from a successful solve — likely singular weighted normal matrix on a heavy-feature / small-effective-N design. Consider RegressionForecaster::wls_logistic_ridge with λ > 0 for the same recency weighting plus L2 regularisation.",
+                                    j, coefs[j]
+                                ));
+                            }
+                        }
+                        if let Some(v) = result.intercept {
+                            if !v.is_finite() {
+                                return Err(format!(
+                                    "WLS: non-finite intercept (= {}) from a successful solve — likely singular weighted normal matrix. Consider wls_logistic_ridge with λ > 0.",
+                                    v
+                                ));
+                            }
+                        }
+                    }
                     Ok(Box::new(fitted))
                 }
                 Self::WlsLogisticRidge { offset, lambda } => {
@@ -5570,6 +5601,53 @@ mod ols_impl {
                 RegressionFeatures::new().trend().no_exog(),
             );
             assert!(model.fit(&ts).is_err());
+        }
+
+        #[test]
+        fn wls_logistic_never_returns_silent_nan_forecast() {
+            // Issue #119: wls_logistic on a heavy-feature / small-
+            // effective-N design previously returned a finite-shaped
+            // forecast whose values were all NaN. The contract we
+            // enforce now is "either the fit errors cleanly, or the
+            // forecast is finite" — silent NaN is never acceptable.
+            // Repro shape mirrors the orchestrator config: short
+            // series, ~ p features close to or exceeding the
+            // effective N (sum of logistic weights).
+            let n = 36;
+            // Construct a synthetic series with a trend.
+            let timestamps = make_timestamps(n);
+            let values: Vec<f64> = (0..n)
+                .map(|i| 5.0 + 0.4 * i as f64 + (i as f64 * 0.5).sin())
+                .collect();
+            let ts = TimeSeries::univariate(timestamps, values).unwrap();
+            // Heavy design: trend + 4 lags + Fourier order 6 for
+            // period 12 (12 sin/cos columns) → ~17 features against
+            // an effective N (sum of logistic weights @ offset 6) ≈ 6.
+            let features = RegressionFeatures::new()
+                .trend()
+                .lags(4)
+                .fourier(12, 6)
+                .no_exog();
+            let mut model = RegressionForecaster::wls_logistic(6.0, features);
+            match model.fit(&ts) {
+                Err(_) => {
+                    // Clean error — acceptable per the #119 contract.
+                }
+                Ok(()) => {
+                    // Successful fit must yield a finite forecast — no
+                    // silent NaN.
+                    let forecast = model
+                        .predict(12)
+                        .expect("Ok fit must produce a finite forecast");
+                    for (h, &v) in forecast.primary().iter().enumerate() {
+                        assert!(
+                            v.is_finite(),
+                            "WLS Logistic produced silent NaN forecast at h={}: {} — regression on #119 fix",
+                            h, v
+                        );
+                    }
+                }
+            }
         }
 
         #[test]

--- a/src/seasonality/auto_trend.rs
+++ b/src/seasonality/auto_trend.rs
@@ -310,13 +310,17 @@ impl TrendComponent for AutoTrend {
             ));
         }
 
-        // PiecewiseLinear
+        // PiecewiseLinear — auto-tune the PELT penalty per series so
+        // the candidate competes fairly in the AICc / BIC / Holdout
+        // bake-off instead of running on the hard-coded default.
         {
             let r = recency.clone();
             candidates.push((
                 "PiecewiseLinear".to_string(),
                 Box::new(move || {
-                    let mut c = PiecewiseLinearTrend::new().with_recency(r);
+                    let mut c = PiecewiseLinearTrend::new()
+                        .with_auto_penalty()
+                        .with_recency(r);
                     c.fit_trend(values).ok()?;
                     Some(FittedTrendComponent::PiecewiseLinear(c))
                 }),

--- a/src/seasonality/piecewise.rs
+++ b/src/seasonality/piecewise.rs
@@ -49,7 +49,11 @@ pub struct PiecewiseLinearTrend {
     /// Minimum segment length for changepoint detection.
     min_segment_length: usize,
     /// Penalty parameter for PELT (higher = fewer changepoints).
+    /// Ignored when `auto_penalty` is true.
     penalty: f64,
+    /// When true, the penalty is chosen per-series via CROPS + elbow
+    /// (`Pelt::auto_detect`). The manual `penalty` field is ignored.
+    auto_penalty: bool,
     /// Recency window for fitting.
     recency: Recency,
     /// Fitted segments: linear regression per segment.
@@ -63,11 +67,12 @@ pub struct PiecewiseLinearTrend {
 impl PiecewiseLinearTrend {
     /// Create a new piecewise linear trend with default parameters.
     ///
-    /// Defaults: penalty = 10.0, min_segment_length = 5.
+    /// Defaults: penalty = 10.0, min_segment_length = 5, auto_penalty = false.
     pub fn new() -> Self {
         Self {
             min_segment_length: 5,
             penalty: 10.0,
+            auto_penalty: false,
             recency: Recency::Full,
             segments: None,
             fitted: Vec::new(),
@@ -77,8 +82,22 @@ impl PiecewiseLinearTrend {
 
     /// Set the penalty parameter (builder-style). Higher values produce fewer
     /// changepoints.
+    ///
+    /// Has no effect when [`Self::with_auto_penalty`] is also set.
     pub fn with_penalty(mut self, penalty: f64) -> Self {
         self.penalty = penalty;
+        self
+    }
+
+    /// Enable per-series automatic penalty selection (builder-style).
+    ///
+    /// At fit time, runs PELT over a geometric range of penalties via
+    /// CROPS (Haynes et al. 2017) and picks the *elbow* where adding one
+    /// more knot stops paying for itself. Removes the need to hand-tune
+    /// the penalty for varying series shapes — useful for batch / global
+    /// pipelines and as the [`super::auto_trend::AutoTrend`] candidate.
+    pub fn with_auto_penalty(mut self) -> Self {
+        self.auto_penalty = true;
         self
     }
 
@@ -193,11 +212,15 @@ impl TrendComponent for PiecewiseLinearTrend {
         let (rec_start, rec_end) = self.recency.resolve_with_data(values);
         let window = &values[rec_start..rec_end];
 
-        // Run PELT changepoint detection on recency window.
-        let pelt = Pelt::new(CostFunction::LinearTrend)
-            .penalty(self.penalty)
-            .min_size(self.min_segment_length);
-        let result = pelt.detect(window);
+        // Run PELT changepoint detection on the recency window. When
+        // auto_penalty is set, sweep via CROPS + elbow; otherwise use
+        // the configured fixed penalty.
+        let pelt = Pelt::new(CostFunction::LinearTrend).min_size(self.min_segment_length);
+        let result = if self.auto_penalty {
+            pelt.auto_detect(window).result
+        } else {
+            pelt.penalty(self.penalty).detect(window)
+        };
 
         // Fit OLS per segment (indices are relative to window, shift to absolute).
         let segments: Vec<Segment> = result
@@ -689,6 +712,81 @@ mod tests {
 
         let forecast = trend.predict_trend(0);
         assert!(forecast.is_empty());
+    }
+
+    // ── Auto-penalty (CROPS + elbow) ───────────────────────────────────
+
+    #[test]
+    fn auto_penalty_recovers_known_slope_change() {
+        // y = 0.5·i for i in 0..40, then 0.5·40 + 2.0·(i − 40) for
+        // i in 40..80. One slope change at index 40; auto_penalty
+        // should land a knot near 40 and recover both slopes within
+        // tolerance, without us having to guess a penalty.
+        let n_first = 40;
+        let slope_first = 0.5;
+        let n_total = 80;
+        let slope_second = 2.0;
+        let break_at = n_first;
+        let level_at_break = slope_first * n_first as f64;
+        let values: Vec<f64> = (0..n_total)
+            .map(|i| {
+                if i < n_first {
+                    slope_first * i as f64
+                } else {
+                    level_at_break + slope_second * (i - n_first) as f64
+                }
+            })
+            .collect();
+
+        let mut trend = PiecewiseLinearTrend::new().with_auto_penalty();
+        trend.fit_trend(&values).unwrap();
+        let segs = trend.segments().expect("segments after fit");
+
+        assert!(
+            segs.len() >= 2,
+            "auto_penalty should detect at least one knot on a clear slope change; got {} segments",
+            segs.len()
+        );
+
+        // Locate the segment containing the constructed break and
+        // confirm its boundary is within ±3 of `break_at`. (±3 absorbs
+        // the elbow heuristic's small tolerance plus the minimum
+        // segment length.)
+        let knot_at = segs[1].start as isize;
+        assert!(
+            (knot_at - break_at as isize).abs() <= 3,
+            "knot landed at {}, expected near {}",
+            knot_at,
+            break_at,
+        );
+
+        // First and last segment slopes should recover the constructed
+        // values within tolerance (allow some slack for the knot being
+        // a few indices off).
+        let first = &segs[0];
+        let last = segs.last().unwrap();
+        assert!(
+            (first.slope - slope_first).abs() < 0.1,
+            "first slope {} should be near {}",
+            first.slope,
+            slope_first,
+        );
+        assert!(
+            (last.slope - slope_second).abs() < 0.1,
+            "last slope {} should be near {}",
+            last.slope,
+            slope_second,
+        );
+    }
+
+    #[test]
+    fn auto_penalty_default_is_off() {
+        // Backwards compat: a default PiecewiseLinearTrend uses the
+        // manual penalty path; flipping auto_penalty must be explicit.
+        let manual = PiecewiseLinearTrend::new();
+        let auto = PiecewiseLinearTrend::new().with_auto_penalty();
+        assert!(!manual.auto_penalty);
+        assert!(auto.auto_penalty);
     }
 
     // ── Constant data ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Patch release **0.8.4 → 0.8.5** bundling two small additions. Both purely additive — no breaking changes.

### Issue #119 — plain WLS rejects silent-NaN coefficients

On heavy-feature / small-effective-N designs (e.g. `wls_logistic` with `offset = 24` against ~20 categorical dummies on a short window), `WlsRegressor` could return a successful result whose coefficients were `NaN`. The NaN propagated into fitted values and forecasts, which silently looked \"successful\" to downstream consumers and quietly dropped the method from honest backtests — the orchestrator's per-fold backtest surfaced 151,656 / 151,656 NaN forecast rows.

The `Wls` fit_to arm now walks `result.coefficients` and `result.intercept` after the solve. Any non-finite entry not explained by `result.aliased` surfaces a clean `Err` pointing the caller at `wls_logistic_ridge` with λ > 0:

```
WLS: non-finite coefficient[5] (= NaN) from a successful solve — likely
singular weighted normal matrix on a heavy-feature / small-effective-N
design. Consider RegressionForecaster::wls_logistic_ridge with λ > 0 for
the same recency weighting plus L2 regularisation.
```

The legitimate pivoted-out aliased path is preserved.

### Auto-penalty `PiecewiseLinearTrend`

`PiecewiseLinearTrend` exposed a manual `penalty` knob (default 10.0) that callers had to hand-tune per series. The underlying PELT detector already supported CROPS + elbow auto-selection via `Pelt::auto_detect`, but `PiecewiseLinearTrend::fit_trend` ignored it.

- New `with_auto_penalty()` builder + `auto_penalty: bool` field (default `false`, preserving v0.8.4 behaviour).
- When set, `fit_trend` runs CROPS + elbow per series via `Pelt::auto_detect` instead of using the manual penalty.
- **`AutoTrend`'s PiecewiseLinear candidate now uses it** — previously it always ran with `penalty = 10`, so PiecewiseLinear could lose to Quadratic on series where a different penalty would have made it the best fit.

```rust
// One-liner: auto-tune knots, then fit
let mut trend = PiecewiseLinearTrend::new().with_auto_penalty();
trend.fit_trend(&values).unwrap();
for seg in trend.segments().unwrap() {
    println!(\"[{}..{})  slope={:.3}\", seg.start, seg.end, seg.slope);
}
```

## Version bumps

- `Cargo.toml`: 0.8.4 → 0.8.5
- `crates/anofox-forecast-js/Cargo.toml`: 0.8.4 → 0.8.5
- `crates/anofox-forecast-js/package.json`: 0.8.4 → 0.8.5
- `js/package.json`: 0.8.4 → 0.8.5
- `Cargo.lock`: regenerated
- `README.md`: install snippet
- `CHANGELOG.md`: new `[0.8.5]` entry

## Test plan

- [x] `cargo test --lib --features serde` — 2905 passed (+3 since 0.8.4): one for #119, two for auto-penalty
- [x] New tests: `wls_logistic_never_returns_silent_nan_forecast`, `auto_penalty_recovers_known_slope_change`, `auto_penalty_default_is_off`
- [x] All integration suites still green (including #106 / #107 conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)