### PR TITLE
Release v0.8.6: TrendType::Logistic (#121) + AutoTrend saturating-series detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-06-17
+
+### Added
+
+- **`TrendType::Logistic`** as a regression-design feature (closes #121). `RegressionFeatures::with_trend_component(TrendType::Logistic)` now fits a `LogisticTrend` (S-curve to capacity `K`) as a `"__logistic_trend"` column in the design matrix. Capacity defaults to `CapacityMode::Auto` (`max(window) × 1.5`), matching the issue's recommendation. Lets `RegressionForecaster` model ramp-up products that plateau — saturating extrapolation rather than runaway linear growth. Mirrors the existing `Exponential` plumbing across `TrendType`, `FittedComponentState`, `feature_names`, `classify_features`, `build_matrices`, and the design-matrix column emission.
+
+- **`LogisticTrend` is now an `AutoTrend` candidate**. The default candidate list grows from `{Linear, Quadratic, Cubic, Exponential, TheilSen, PiecewiseLinear (auto-penalty)}` to also include `Logistic`. Doubles as a **saturating-series detector** — after `AutoTrend::fit_trend`, reading `selection_result().selected == "Logistic"` (or `"Logistic"` ranking ahead of `"Exponential"` in `scores`) flags an S-curve. Composes with the v0.8.5 auto-penalty `PiecewiseLinear` candidate: both are valid saturation detectors and the user gets both signals from one fit.
+
+### Known limitation
+
+- `LogisticTrend::CapacityMode::Auto` uses `K = max(window) × 1.5`. On series that haven't fully saturated, that under-estimates the true ceiling and biases the linearised fit. If you have prior knowledge of the cap, `LogisticTrend::new().with_capacity(K)` recovers the right shape. Joint MLE over `(K, r, t₀)` is a possible future refinement.
+
 ## [0.8.5] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.8.5"
+anofox-forecast = "0.8.6"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -48,6 +48,7 @@ mod ols_impl {
     use crate::seasonality::dummy::DummySeasonality;
     use crate::seasonality::exponential_trend::ExponentialTrend;
     use crate::seasonality::fourier::fourier_terms;
+    use crate::seasonality::logistic_trend::LogisticTrend;
     use crate::seasonality::polynomial::PolynomialTrend;
     use crate::seasonality::theilsen::TheilSenTrend;
     use crate::seasonality::traits::{Recency, SeasonalComponent, TrendComponent};
@@ -1424,6 +1425,12 @@ mod ols_impl {
         /// Exponential trend via [`ExponentialTrend`](crate::seasonality::ExponentialTrend).
         /// Requires positive values.
         Exponential,
+        /// Logistic / saturating trend via
+        /// [`LogisticTrend`](crate::seasonality::LogisticTrend). Capacity
+        /// `K` is estimated automatically (`CapacityMode::Auto`) — useful
+        /// for ramp-up products that plateau toward a saturating ceiling
+        /// instead of extrapolating linearly. Closes #121.
+        Logistic,
         /// Theil-Sen robust linear trend via [`TheilSenTrend`](crate::seasonality::TheilSenTrend).
         TheilSen,
     }
@@ -1477,6 +1484,7 @@ mod ols_impl {
     enum FittedComponentState {
         Polynomial(PolynomialTrend),
         Exponential(ExponentialTrend),
+        Logistic(LogisticTrend),
         TheilSen(TheilSenTrend),
         Dummy(DummySeasonality),
         Fourier {
@@ -1494,9 +1502,11 @@ mod ols_impl {
         /// Number of columns this component contributes to the design matrix.
         fn n_columns(&self) -> usize {
             match self {
-                Self::Polynomial(_) | Self::Exponential(_) | Self::TheilSen(_) | Self::Dummy(_) => {
-                    1
-                }
+                Self::Polynomial(_)
+                | Self::Exponential(_)
+                | Self::Logistic(_)
+                | Self::TheilSen(_)
+                | Self::Dummy(_) => 1,
                 Self::Fourier { order, .. } => 2 * order,
                 Self::Structural { fill_values } => fill_values.len(),
             }
@@ -1510,6 +1520,7 @@ mod ols_impl {
             match self {
                 Self::Polynomial(p) => vec![p.predict_trend(horizon)],
                 Self::Exponential(e) => vec![e.predict_trend(horizon)],
+                Self::Logistic(l) => vec![l.predict_trend(horizon)],
                 Self::TheilSen(t) => vec![t.predict_trend(horizon)],
                 Self::Dummy(d) => vec![d.predict_seasonal(horizon)],
                 Self::Fourier { period, order } => {
@@ -2372,6 +2383,7 @@ mod ols_impl {
                     TrendType::Quadratic => names.push("__quadratic_trend".to_string()),
                     TrendType::Cubic => names.push("__cubic_trend".to_string()),
                     TrendType::Exponential => names.push("__exp_trend".to_string()),
+                    TrendType::Logistic => names.push("__logistic_trend".to_string()),
                     TrendType::TheilSen => names.push("__theilsen_trend".to_string()),
                 }
             }
@@ -2425,6 +2437,7 @@ mod ols_impl {
                     TrendType::Quadratic => "__quadratic_trend",
                     TrendType::Cubic => "__cubic_trend",
                     TrendType::Exponential => "__exp_trend",
+                    TrendType::Logistic => "__logistic_trend",
                     TrendType::TheilSen => "__theilsen_trend",
                 };
                 result.push((name.to_string(), trend.safety()));
@@ -2584,6 +2597,11 @@ mod ols_impl {
                         e.fit_trend(values)?;
                         FittedComponentState::Exponential(e)
                     }
+                    TrendType::Logistic => {
+                        let mut l = LogisticTrend::new().with_recency(Recency::Full);
+                        l.fit_trend(values)?;
+                        FittedComponentState::Logistic(l)
+                    }
                     TrendType::TheilSen => {
                         let mut t = TheilSenTrend::new().with_recency(Recency::Full);
                         t.fit_trend(values)?;
@@ -2649,6 +2667,13 @@ mod ols_impl {
                     }
                     FittedComponentState::Exponential(e) => {
                         let fitted = e.fitted_trend();
+                        for i in 0..n_train {
+                            x[(i, col_idx)] = fitted[offset + i];
+                        }
+                        col_idx += 1;
+                    }
+                    FittedComponentState::Logistic(l) => {
+                        let fitted = l.fitted_trend();
                         for i in 0..n_train {
                             x[(i, col_idx)] = fitted[offset + i];
                         }
@@ -4910,6 +4935,71 @@ mod ols_impl {
                 assert!(v.is_finite());
                 assert!(v > 0.0, "exponential trend should predict positive values");
             }
+        }
+
+        #[test]
+        fn ols_logistic_trend_component_saturates() {
+            // Issue #121: TrendType::Logistic uses LogisticTrend (S-curve
+            // to capacity K). On a saturating series the fitted column
+            // should be finite, drive a sensible forecast, and not
+            // explode linearly the way TrendType::Linear would.
+            // Capacity defaults to max(window) * 1.5 — so K ≈ 30 here.
+            let n = 60;
+            let k_true = 20.0;
+            // Logistic of the form K / (1 + exp(-r·(t − t0)))
+            let r = 0.15;
+            let t0 = 30.0;
+            let values: Vec<f64> = (0..n)
+                .map(|i| k_true / (1.0 + (-r * (i as f64 - t0)).exp()))
+                .collect();
+            let ts = TimeSeries::univariate(make_timestamps(n), values).unwrap();
+
+            let features = RegressionFeatures::new()
+                .no_trend()
+                .with_trend_component(TrendType::Logistic)
+                .no_exog();
+
+            // Feature-name sanity.
+            let names = features.feature_names(&[]);
+            assert!(
+                names.contains(&"__logistic_trend".to_string()),
+                "expected __logistic_trend in feature names, got {:?}",
+                names,
+            );
+
+            let mut model = RegressionForecaster::ols(features);
+            model.fit(&ts).unwrap();
+
+            let fitted = model.fitted_values().expect("fitted after fit");
+            for &v in fitted {
+                assert!(v.is_finite(), "fitted value not finite: {}", v);
+            }
+
+            let horizon = 30;
+            let forecast = model.predict(horizon).unwrap();
+            let preds = forecast.primary();
+            // Forecast saturates: every step must stay finite and
+            // bounded by 2·K_true (loose upper to absorb estimation
+            // noise — the key contract is "doesn't extrapolate
+            // linearly off to infinity").
+            let ceiling = 2.0 * k_true;
+            for (h, &v) in preds.iter().enumerate() {
+                assert!(v.is_finite(), "predicted h={} not finite: {}", h, v);
+                assert!(
+                    v.abs() < ceiling,
+                    "logistic-trend forecast h={} = {} exceeded saturation ceiling {} — should plateau, not run away",
+                    h, v, ceiling
+                );
+            }
+            // Far-future increment must be much smaller than the
+            // early-growth increment (saturation property).
+            let mid_growth = (preds[5] - preds[0]).abs();
+            let tail_growth = (preds[horizon - 1] - preds[horizon - 6]).abs();
+            assert!(
+                tail_growth <= mid_growth + 1e-6,
+                "logistic forecast should saturate: tail_growth = {} should not exceed mid_growth = {}",
+                tail_growth, mid_growth
+            );
         }
 
         #[test]

--- a/src/seasonality/auto_trend.rs
+++ b/src/seasonality/auto_trend.rs
@@ -22,6 +22,7 @@
 //! ```
 
 use super::exponential_trend::ExponentialTrend;
+use super::logistic_trend::LogisticTrend;
 use super::piecewise::PiecewiseLinearTrend;
 use super::polynomial::PolynomialTrend;
 use super::theilsen::TheilSenTrend;
@@ -56,6 +57,7 @@ pub struct AutoTrendResult {
 enum FittedTrendComponent {
     Polynomial(PolynomialTrend),
     Exponential(ExponentialTrend),
+    Logistic(LogisticTrend),
     PiecewiseLinear(PiecewiseLinearTrend),
     TheilSen(TheilSenTrend),
 }
@@ -65,6 +67,7 @@ impl FittedTrendComponent {
         match self {
             Self::Polynomial(c) => c.fitted_trend(),
             Self::Exponential(c) => c.fitted_trend(),
+            Self::Logistic(c) => c.fitted_trend(),
             Self::PiecewiseLinear(c) => c.fitted_trend(),
             Self::TheilSen(c) => c.fitted_trend(),
         }
@@ -74,6 +77,7 @@ impl FittedTrendComponent {
         match self {
             Self::Polynomial(c) => c.predict_trend(n_ahead),
             Self::Exponential(c) => c.predict_trend(n_ahead),
+            Self::Logistic(c) => c.predict_trend(n_ahead),
             Self::PiecewiseLinear(c) => c.predict_trend(n_ahead),
             Self::TheilSen(c) => c.predict_trend(n_ahead),
         }
@@ -83,6 +87,7 @@ impl FittedTrendComponent {
         match self {
             Self::Polynomial(c) => c.trend_features(),
             Self::Exponential(c) => c.trend_features(),
+            Self::Logistic(c) => c.trend_features(),
             Self::PiecewiseLinear(c) => c.trend_features(),
             Self::TheilSen(c) => c.trend_features(),
         }
@@ -92,6 +97,7 @@ impl FittedTrendComponent {
         match self {
             Self::Polynomial(c) => c.trend_name(),
             Self::Exponential(c) => c.trend_name(),
+            Self::Logistic(c) => c.trend_name(),
             Self::PiecewiseLinear(c) => c.trend_name(),
             Self::TheilSen(c) => c.trend_name(),
         }
@@ -101,6 +107,7 @@ impl FittedTrendComponent {
         match self {
             Self::Polynomial(c) => c.n_params(),
             Self::Exponential(c) => c.n_params(),
+            Self::Logistic(c) => c.n_params(),
             Self::PiecewiseLinear(c) => c.n_params(),
             Self::TheilSen(c) => c.n_params(),
         }
@@ -113,7 +120,8 @@ impl FittedTrendComponent {
 /// an information criterion (AICc by default).
 ///
 /// Default candidates: Linear (poly1), Quadratic (poly2), Exponential (if data
-/// positive), TheilSen, PiecewiseLinear.
+/// positive), Logistic (S-curve to auto-estimated capacity K), TheilSen,
+/// PiecewiseLinear.
 #[derive(Debug, Clone)]
 pub struct AutoTrend {
     /// Recency specification for all candidates.
@@ -297,6 +305,23 @@ impl TrendComponent for AutoTrend {
             ));
         }
 
+        // Logistic / saturating (S-curve). LogisticTrend estimates its
+        // own capacity K via CapacityMode::Auto, so no precondition on
+        // the data. The candidate doubles as a detector: when the
+        // winning trend is "Logistic", the series exhibits ramp-up +
+        // saturation rather than open-ended linear/exponential growth.
+        {
+            let r = recency.clone();
+            candidates.push((
+                "Logistic".to_string(),
+                Box::new(move || {
+                    let mut c = LogisticTrend::new().with_recency(r);
+                    c.fit_trend(values).ok()?;
+                    Some(FittedTrendComponent::Logistic(c))
+                }),
+            ));
+        }
+
         // TheilSen
         {
             let r = recency.clone();
@@ -462,6 +487,55 @@ mod tests {
             "scores: {:?}",
             result.scores
         );
+    }
+
+    // ── Logistic / saturating data → Logistic candidate available + beats Exponential ───
+
+    #[test]
+    fn logistic_candidate_present_and_beats_exponential_on_saturating_data() {
+        // S-curve to capacity K = 100, inflection at t = 50.
+        //
+        // Two contracts:
+        //   1. The Logistic candidate must appear in the scoreboard — it
+        //      can't silently drop out (= the plumbing is correct).
+        //   2. On a clearly saturating series, Logistic must rank ahead
+        //      of Exponential — the meaningful detection signal vs
+        //      open-ended growth.
+        //
+        // We intentionally don't require "Logistic wins outright":
+        // PiecewiseLinear with auto-penalty (v0.8.5) can piece an S-curve
+        // into short linear segments and win on AICc legitimately. The
+        // user combines these — both are valid detectors of saturation.
+        let k_true = 100.0;
+        let r = 0.12;
+        let t0 = 50.0;
+        let values: Vec<f64> = (0..120)
+            .map(|i| k_true / (1.0 + (-r * (i as f64 - t0)).exp()))
+            .collect();
+        let mut auto = AutoTrend::new().with_recency(Recency::Full);
+        auto.fit_trend(&values).unwrap();
+
+        let result = auto.selection_result().unwrap();
+        let names: Vec<&str> = result.scores.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"Logistic"),
+            "Logistic candidate missing from scoreboard: {:?}",
+            names,
+        );
+
+        let logistic = result
+            .scores
+            .iter()
+            .find(|(n, _)| n == "Logistic")
+            .unwrap()
+            .1;
+        if let Some(&(_, exponential)) = result.scores.iter().find(|(n, _)| n == "Exponential") {
+            assert!(
+                logistic < exponential,
+                "On a saturating series, Logistic ({}) should rank ahead of Exponential ({}); scores: {:?}",
+                logistic, exponential, result.scores,
+            );
+        }
     }
 
     // ── Quadratic data → should select Quadratic ──────────────────────


### PR DESCRIPTION
## Summary

Patch release **0.8.5 → 0.8.6** adding two composable pieces: a regression-design feature for saturating-growth trends, and a detector for the same shape via `AutoTrend`. Both additive — no breaking changes.

### Issue #121 — `TrendType::Logistic` as a regression feature

`RegressionFeatures` accepted trend only via the `TrendType` enum (Linear, Quadratic, Cubic, Exponential, TheilSen, plus arbitrary `StructuralFeature`s). `LogisticTrend` implemented `TrendComponent` but had no entry point — so a `RegressionForecaster` couldn't fit a saturating-growth column without writing a custom wrapper.

```rust
let mut model = RegressionForecaster::ols(
    RegressionFeatures::new()
        .no_trend()
        .with_trend_component(TrendType::Logistic)
        .no_exog(),
);
model.fit(&ts)?;
let forecast = model.predict(30)?;
// Saturates rather than running away linearly.
```

Capacity `K` defaults to `CapacityMode::Auto` (`max(window) × 1.5`).

### AutoTrend — saturating-series detector

`AutoTrend` already auto-selected from `{Linear, Quadratic, Cubic, Exponential, TheilSen, PiecewiseLinear (auto-penalty)}` but had no `Logistic` candidate, so on a saturating series the user couldn't read \"Logistic\" off the selection result — even with #121's new feature available, there was no way to detect when to apply it.

```rust
let mut auto = AutoTrend::new();
auto.fit_trend(&values)?;
let r = auto.selection_result().unwrap();

if r.selected == \"Logistic\" {
    // S-curve detected — fit a RegressionForecaster with TrendType::Logistic
}
// r.scores: AICc gap to other candidates gives confidence, not just yes/no
```

The two changes compose: AutoTrend tells you **whether** the series saturates, the regression feature tells you **how** to model it.

## Known limitation

`LogisticTrend::CapacityMode::Auto` uses `K = max(window) × 1.5`. On series that haven't fully saturated, that under-estimates the true ceiling and biases the linearised fit. If you have prior knowledge of the cap, `LogisticTrend::new().with_capacity(K)` recovers the right shape. Joint MLE over `(K, r, t₀)` is a possible future refinement.

## Version bumps

- `Cargo.toml`: 0.8.5 → 0.8.6
- `crates/anofox-forecast-js/Cargo.toml`: 0.8.5 → 0.8.6
- `crates/anofox-forecast-js/package.json`: 0.8.5 → 0.8.6
- `js/package.json`: 0.8.5 → 0.8.6
- `Cargo.lock`: regenerated
- `README.md`: install snippet
- `CHANGELOG.md`: new `[0.8.6]` entry

## Test plan

- [x] `cargo test --lib --features serde` — 2907 passed (+2 since 0.8.5)
- [x] New regression tests:
  - `ols_logistic_trend_component_saturates` — `TrendType::Logistic` produces a finite, saturating-bounded forecast.
  - `logistic_candidate_present_and_beats_exponential_on_saturating_data` — Logistic appears in AutoTrend's scoreboard and outranks Exponential on a clean S-curve.
- [x] All integration suites still green (including #106 / #107 conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)