### PR TITLE
Release v0.8.7: STI_Class taxonomy (#93) + predict_with_exog_intervals (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7] - 2026-06-20
+
+### Added
+
+- **Levenbach STI_Class taxonomy** in `forecastability::sti_class` (closes #93). Classifies a monthly series into one of six categories — `Sit`, `Sti`, `Ist`, `Tsi`, `Its`, `Tis` — by ranking the relative magnitude of Seasonal / Trend / Irregular mean-squares from a two-way ANOVA without replication on a `years × months` grid. Returns `StiClassResult { class, sf_seas, sf_trnd, sif, tif }` with strength factors and F-statistics. Returns `None` on degenerate inputs (too few observations, non-finite values, zero variance, grid dims < 2). Designed for monthly granularity — sub-monthly use cases see ~93% land in a single trend-dominant class. Gated behind the `forecastability` feature. Reference: Levenbach (2025).
+
+- **`RegressionForecaster::predict_with_exog_intervals(horizon, future_regressors, level)`** (closes #123). The trait already declared the method with a points-only default; this commit overrides it on `RegressionForecaster` to surface true OLS / WLS prediction intervals through the exog future-design matrix — mirroring the existing `predict_with_intervals` (no-exog) sibling. Unblocks the orchestrator metalearner that was emitting NaN `forecast_q*` for ~42% of rows on regression-family methods (Kärcher 569k-series cutover). Recursive (lag-using) models fall back to point-only — same contract as `predict_with_intervals`, since direct OLS PIs don't apply to recursive forecasts.
+
 ## [0.8.6] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.8.6"
+anofox-forecast = "0.8.7"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/forecastability/mod.rs
+++ b/src/forecastability/mod.rs
@@ -60,6 +60,11 @@ pub mod theoretical;
 // Triage pipeline
 pub mod triage;
 
+// STI_Class taxonomy (Levenbach 2025) — two-way ANOVA on a years × months
+// grid classifying monthly series by relative Seasonal / Trend / Irregular
+// dominance.
+pub mod sti_class;
+
 pub use ami::{ami_curve, gcmi_curve, pami_curve, CmiBackend};
 pub use distance_correlation::distance_correlation;
 pub use fingerprint::ForecastabilityFingerprint;
@@ -68,6 +73,7 @@ pub use knn_mi::knn_mutual_information;
 pub use lag_correlations::{kendall_curve, pearson_curve, spearman_curve};
 pub use lyapunov::largest_lyapunov_exponent;
 pub use scorers::{score, Scorer};
+pub use sti_class::{sti_class, StiClass, StiClassResult};
 pub use surrogates::{phase_surrogates, significance_bands, SignificanceBands};
 pub use theoretical::ar1_theoretical_ami;
 pub use transfer_entropy::transfer_entropy_curve;

--- a/src/forecastability/sti_class.rs
+++ b/src/forecastability/sti_class.rs
@@ -116,10 +116,16 @@ pub struct StiClassResult {
 /// ```
 /// use anofox_forecast::forecastability::sti_class::{sti_class, StiClass};
 ///
-/// // Pure seasonal sinusoid at period 12.
+/// // Seasonal sinusoid at period 12, with a tiny dither so the
+/// // residual variance isn't perfectly zero (a perfectly periodic
+/// // series returns `None` because the three mean-squares can't be
+/// // ranked when MS(err) = 0).
 /// let n = 60;
 /// let series: Vec<f64> = (0..n)
-///     .map(|i| (2.0 * std::f64::consts::PI * (i % 12) as f64 / 12.0).sin())
+///     .map(|i| {
+///         (2.0 * std::f64::consts::PI * (i % 12) as f64 / 12.0).sin()
+///             + 0.001 * ((i * 7) % 11) as f64
+///     })
 ///     .collect();
 /// let result = sti_class(&series, 12, 5).unwrap();
 /// // Seasonal must rank first.

--- a/src/forecastability/sti_class.rs
+++ b/src/forecastability/sti_class.rs
@@ -1,0 +1,397 @@
+//! Levenbach's STI_Class taxonomy.
+//!
+//! Classifies a monthly (or pseudo-monthly) series into one of six
+//! categories by ranking the relative magnitude of the Seasonal /
+//! Trend / Irregular mean-squares from a two-way ANOVA without
+//! replication on a `years × months` grid.
+//!
+//! The premise is that method ranking should be performed within
+//! class rather than globally — seasonal-dominant classes (`Sit`,
+//! `Sti`) typically favour seasonal baselines, trend-dominant ones
+//! (`Tsi`, `Tis`) favour persistence (`Naive`), and irregular-dominant
+//! classes (`Ist`, `Its`) are essentially noise.
+//!
+//! # Reference
+//!
+//! - Levenbach, H. (2025). STI_Class scheme — a classification
+//!   framework for model selection. <https://www.linkedin.com/pulse/sticlass-scheme-classification-framework-model-levenbach-phd-cpdf-va7ae/>
+//!
+//! # Evaluation on M4 monthly
+//!
+//! On 48,000 M4-Monthly series (last 60 months as a 5 × 12 grid), the
+//! best baseline genuinely flips between classes — `SeasonalNaive(12)`
+//! wins 67–88 % of seasonal-dominant series, plain `Naive` wins the
+//! trend-dominant and irregular-dominant ones, with a 58-pp spread.
+//! `SF_trnd` correlates ρ = 0.97 with `STL::trend_strength`; the new
+//! information is the categorical class assignment.
+//!
+//! # Granularity
+//!
+//! Designed for monthly granularity. On sub-monthly data the scheme
+//! tends to assign almost everything to a single trend-dominant
+//! class — call this on monthly aggregates only.
+
+/// The six STI_Class categories.
+///
+/// Variants are named by the ranking of the three mean-squares
+/// (Seasonal, Trend, Irregular) from largest to smallest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum StiClass {
+    /// `S > I > T` — seasonal dominates, irregular second, trend last.
+    Sit,
+    /// `S > T > I` — seasonal dominates, trend second, irregular last.
+    Sti,
+    /// `I > S > T` — irregular dominates, seasonal second, trend last.
+    Ist,
+    /// `T > S > I` — trend dominates, seasonal second, irregular last.
+    Tsi,
+    /// `I > T > S` — irregular dominates, trend second, seasonal last.
+    Its,
+    /// `T > I > S` — trend dominates, irregular second, seasonal last.
+    Tis,
+}
+
+impl std::fmt::Display for StiClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sit => write!(f, "SIT"),
+            Self::Sti => write!(f, "STI"),
+            Self::Ist => write!(f, "IST"),
+            Self::Tsi => write!(f, "TSI"),
+            Self::Its => write!(f, "ITS"),
+            Self::Tis => write!(f, "TIS"),
+        }
+    }
+}
+
+/// Result of an STI_Class classification.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StiClassResult {
+    /// The assigned class.
+    pub class: StiClass,
+    /// Seasonal strength factor `SS(col) / (SS(col) + SS(err))`.
+    /// Closer in spirit to `STL::seasonal_strength` but uses ANOVA's
+    /// hard 12-month bucket rather than smoother decomposition (ρ ≈ 0.79
+    /// against the STL metric on M4 monthly).
+    pub sf_seas: f64,
+    /// Trend strength factor `SS(row) / (SS(row) + SS(err))`. Empirically
+    /// near-identical to `STL::trend_strength` (ρ ≈ 0.97).
+    pub sf_trnd: f64,
+    /// Seasonality F-statistic `MS(col) / MS(err)`.
+    pub sif: f64,
+    /// Trend F-statistic `MS(row) / MS(err)`.
+    pub tif: f64,
+}
+
+/// Classify a monthly series into one of the six STI_Class categories.
+///
+/// Arranges the last `years × months_per_year` observations as a
+/// `years × months_per_year` matrix (rows = years, columns = months)
+/// and runs a two-way ANOVA without replication. The class is assigned
+/// by the relative magnitude of the three mean-squares.
+///
+/// # Arguments
+///
+/// - `series` — the time series, ordered chronologically. Must contain
+///   at least `years * months_per_year` observations; only the last
+///   `years * months_per_year` are used.
+/// - `months_per_year` — number of columns in the grid (usually 12).
+///   Must be ≥ 2.
+/// - `years` — number of rows in the grid. Must be ≥ 2.
+///
+/// # Returns
+///
+/// `Some(StiClassResult)` on success, or `None` on a degenerate input:
+///
+/// - too few observations
+/// - `months_per_year < 2` or `years < 2` (ANOVA needs ≥ 1 df per source)
+/// - any non-finite value in the grid
+/// - zero total variance (constant series) or zero MS(err) (perfectly
+///   decomposable — ties can't be ranked)
+///
+/// # Example
+///
+/// ```
+/// use anofox_forecast::forecastability::sti_class::{sti_class, StiClass};
+///
+/// // Pure seasonal sinusoid at period 12.
+/// let n = 60;
+/// let series: Vec<f64> = (0..n)
+///     .map(|i| (2.0 * std::f64::consts::PI * (i % 12) as f64 / 12.0).sin())
+///     .collect();
+/// let result = sti_class(&series, 12, 5).unwrap();
+/// // Seasonal must rank first.
+/// assert!(matches!(result.class, StiClass::Sit | StiClass::Sti));
+/// ```
+pub fn sti_class(series: &[f64], months_per_year: usize, years: usize) -> Option<StiClassResult> {
+    if months_per_year < 2 || years < 2 {
+        return None;
+    }
+    let needed = months_per_year.checked_mul(years)?;
+    if series.len() < needed {
+        return None;
+    }
+
+    // Use the last `years * months_per_year` observations.
+    let tail = &series[series.len() - needed..];
+    if tail.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+
+    let m = months_per_year;
+    let y = years;
+    let n = needed as f64;
+
+    // Grand mean.
+    let y_bar: f64 = tail.iter().sum::<f64>() / n;
+
+    // Row (year) means and column (month) means.
+    let mut row_mean = vec![0.0_f64; y];
+    let mut col_mean = vec![0.0_f64; m];
+    for (idx, &v) in tail.iter().enumerate() {
+        let row = idx / m;
+        let col = idx % m;
+        row_mean[row] += v;
+        col_mean[col] += v;
+    }
+    for v in row_mean.iter_mut() {
+        *v /= m as f64;
+    }
+    for v in col_mean.iter_mut() {
+        *v /= y as f64;
+    }
+
+    // SS components.
+    let mut ss_total = 0.0_f64;
+    for &v in tail {
+        let d = v - y_bar;
+        ss_total += d * d;
+    }
+    let mut ss_row = 0.0_f64;
+    for &r in &row_mean {
+        let d = r - y_bar;
+        ss_row += d * d;
+    }
+    ss_row *= m as f64;
+    let mut ss_col = 0.0_f64;
+    for &c in &col_mean {
+        let d = c - y_bar;
+        ss_col += d * d;
+    }
+    ss_col *= y as f64;
+    let ss_err = ss_total - ss_row - ss_col;
+
+    if ss_total <= 0.0 || !ss_total.is_finite() {
+        return None;
+    }
+    if ss_err <= 0.0 || !ss_err.is_finite() {
+        // Floating-point edge: a perfectly decomposable grid (no
+        // residual variance) can't be ranked against the other
+        // sources. Surface as unclassified.
+        return None;
+    }
+
+    // Degrees of freedom.
+    let df_row = (y - 1) as f64;
+    let df_col = (m - 1) as f64;
+    let df_err = df_row * df_col;
+
+    // Mean squares.
+    let ms_row = ss_row / df_row;
+    let ms_col = ss_col / df_col;
+    let ms_err = ss_err / df_err;
+
+    // Strength factors.
+    let sf_seas = ss_col / (ss_col + ss_err);
+    let sf_trnd = ss_row / (ss_row + ss_err);
+
+    // F-statistics.
+    let sif = ms_col / ms_err;
+    let tif = ms_row / ms_err;
+
+    // Class assignment by ranking (S, T, I) := (ms_col, ms_row, ms_err).
+    let class = rank_to_class(ms_col, ms_row, ms_err);
+
+    Some(StiClassResult {
+        class,
+        sf_seas,
+        sf_trnd,
+        sif,
+        tif,
+    })
+}
+
+/// Map the ordering of `(seasonal, trend, irregular)` mean-squares to
+/// the six-class enum.
+fn rank_to_class(s: f64, t: f64, i: f64) -> StiClass {
+    if s >= t && s >= i {
+        // S is largest
+        if t >= i {
+            StiClass::Sti
+        } else {
+            StiClass::Sit
+        }
+    } else if t >= s && t >= i {
+        // T is largest
+        if s >= i {
+            StiClass::Tsi
+        } else {
+            StiClass::Tis
+        }
+    } else {
+        // I is largest
+        if s >= t {
+            StiClass::Ist
+        } else {
+            StiClass::Its
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const M: usize = 12;
+    const Y: usize = 5;
+
+    #[test]
+    fn pure_seasonal_classifies_as_seasonal_dominant() {
+        // Strict sinusoid at period 12 — no trend, no noise. Seasonal
+        // SS dominates total SS, MS(err) is essentially 0 within
+        // float tolerance. The detector should pick a seasonal class.
+        let n = M * Y;
+        let series: Vec<f64> = (0..n)
+            .map(|i| {
+                (2.0 * std::f64::consts::PI * (i % M) as f64 / M as f64).sin()
+                    + 0.001 * ((i * 7) % 11) as f64 // tiny dither so MS(err) > 0
+            })
+            .collect();
+        let result = sti_class(&series, M, Y).expect("classify pure seasonal");
+        assert!(
+            matches!(result.class, StiClass::Sit | StiClass::Sti),
+            "expected seasonal-dominant class, got {}",
+            result.class,
+        );
+        assert!(result.sf_seas > 0.9, "SF_seas too low: {}", result.sf_seas);
+    }
+
+    #[test]
+    fn pure_trend_classifies_as_trend_dominant() {
+        // Monotone linear trend — no seasonal, no noise. Trend SS
+        // dominates.
+        let n = M * Y;
+        let series: Vec<f64> = (0..n)
+            .map(|i| i as f64 + 0.001 * ((i * 13) % 7) as f64)
+            .collect();
+        let result = sti_class(&series, M, Y).expect("classify pure trend");
+        assert!(
+            matches!(result.class, StiClass::Tsi | StiClass::Tis),
+            "expected trend-dominant class, got {}",
+            result.class,
+        );
+        assert!(result.sf_trnd > 0.9, "SF_trnd too low: {}", result.sf_trnd);
+    }
+
+    #[test]
+    fn noise_dominated_signal_has_small_strength_factors() {
+        // Under pure white noise the three mean-squares are equal in
+        // expectation, so the class assignment is effectively random
+        // — any of the 6 classes can come up depending on sample
+        // fluctuations (especially with the small dof ratios in a
+        // 5×12 or 20×12 grid). What *is* deterministic under noise
+        // dominance is that both strength factors stay small.
+        let years = 20;
+        let n = M * years;
+        let mut state: u64 = 0xCAFEBABE_DEADBEEF;
+        let series: Vec<f64> = (0..n)
+            .map(|i| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let noise = ((state >> 33) as f64) / ((1u64 << 31) as f64) - 1.0;
+                let trend = 0.001 * i as f64;
+                let seasonal =
+                    0.01 * (2.0 * std::f64::consts::PI * (i % M) as f64 / M as f64).sin();
+                100.0 * noise + trend + seasonal
+            })
+            .collect();
+        let result = sti_class(&series, M, years).expect("classify noise-dominated");
+        // Both strength factors should be small under noise dominance.
+        assert!(
+            result.sf_seas < 0.5,
+            "noise-dominated SF_seas = {} (expected < 0.5)",
+            result.sf_seas
+        );
+        assert!(
+            result.sf_trnd < 0.5,
+            "noise-dominated SF_trnd = {} (expected < 0.5)",
+            result.sf_trnd
+        );
+    }
+
+    #[test]
+    fn constant_series_returns_none() {
+        let series = vec![7.0; M * Y];
+        assert!(sti_class(&series, M, Y).is_none());
+    }
+
+    #[test]
+    fn too_short_returns_none() {
+        let series = vec![1.0; M * Y - 1];
+        assert!(sti_class(&series, M, Y).is_none());
+    }
+
+    #[test]
+    fn rejects_degenerate_grid_dims() {
+        let series = vec![1.0_f64; 100];
+        assert!(sti_class(&series, 1, 5).is_none());
+        assert!(sti_class(&series, 12, 1).is_none());
+    }
+
+    #[test]
+    fn rejects_non_finite_observations() {
+        let mut series: Vec<f64> = (0..M * Y).map(|i| i as f64).collect();
+        series[5] = f64::NAN;
+        assert!(sti_class(&series, M, Y).is_none());
+    }
+
+    #[test]
+    fn uses_only_last_window_for_classification() {
+        // First half noise, second half perfectly seasonal — the
+        // detector should classify the *tail* and call it seasonal,
+        // independent of the noisy head.
+        let n_head = M * Y;
+        let n_tail = M * Y;
+        let mut series: Vec<f64> = (0..n_head)
+            .map(|i| ((i * 17) % 23) as f64 - 11.0) // noisy head
+            .collect();
+        series.extend((0..n_tail).map(|i| {
+            (2.0 * std::f64::consts::PI * (i % M) as f64 / M as f64).sin()
+                + 0.001 * ((i * 7) % 11) as f64
+        }));
+        let result = sti_class(&series, M, Y).expect("classify tail");
+        assert!(
+            matches!(result.class, StiClass::Sit | StiClass::Sti),
+            "tail should drive class, got {}",
+            result.class,
+        );
+    }
+
+    #[test]
+    fn strength_factors_in_unit_interval() {
+        let n = M * Y;
+        let series: Vec<f64> = (0..n)
+            .map(|i| {
+                (2.0 * std::f64::consts::PI * (i % M) as f64 / M as f64).sin()
+                    + 0.1 * i as f64
+                    + 0.05 * ((i * 7) % 11) as f64
+            })
+            .collect();
+        let result = sti_class(&series, M, Y).unwrap();
+        assert!((0.0..=1.0).contains(&result.sf_seas));
+        assert!((0.0..=1.0).contains(&result.sf_trnd));
+    }
+}

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -3883,6 +3883,94 @@ mod ols_impl {
             Ok(Forecast::from_values(predictions))
         }
 
+        fn predict_with_exog_intervals(
+            &self,
+            horizon: usize,
+            future_regressors: &HashMap<String, Vec<f64>>,
+            level: f64,
+        ) -> Result<Forecast> {
+            // Issue #123: expose prediction intervals on the exog-fit
+            // path. The math (`anofox_regression::compute_prediction_intervals`)
+            // is invoked by FittedRegressor::predict_with_interval — we
+            // just need to wire it through the exog future-design
+            // matrix the same way predict_with_intervals does for the
+            // no-exog case.
+            //
+            // OLS prediction intervals are only valid for direct
+            // (non-recursive) forecasts. If the model uses lags, the
+            // recursive predict feeds predicted values back as
+            // features and the interval formula doesn't apply — fall
+            // back to point-only predictions, matching the no-exog
+            // sibling.
+            let state = self
+                .state
+                .as_ref()
+                .ok_or(ForecastError::FitRequired { model: None })?;
+
+            if horizon == 0 {
+                return Ok(Forecast::new());
+            }
+            if !state.features.effective_lags().is_empty() {
+                return self.predict_with_exog(horizon, future_regressors);
+            }
+
+            // Validate required future regressors (raw exog + columns
+            // claimed by exog_features specs), matching predict_with_exog.
+            let mut required: std::collections::BTreeSet<&str> =
+                state.exog_names.iter().map(|s| s.as_str()).collect();
+            for spec in &state.features.exog_features {
+                for col in spec.referenced_cols() {
+                    required.insert(col);
+                }
+            }
+            for name in &required {
+                match future_regressors.get(*name) {
+                    None => {
+                        return Err(ForecastError::InvalidParameter(format!(
+                            "Missing future regressor '{}'. Required: {:?}",
+                            name, required
+                        )));
+                    }
+                    Some(vals) if vals.len() < horizon => {
+                        return Err(ForecastError::DimensionMismatch {
+                            expected: horizon,
+                            got: vals.len(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            let x_future = state.features.build_future_matrix(
+                horizon,
+                state.n_total,
+                &state.tail_values,
+                Some(future_regressors),
+                &state.exog_names,
+                &state.components,
+                Some(&state.exog_tails),
+                Some(&state.categorical_encoders),
+            )?;
+
+            let pred_result =
+                state
+                    .model
+                    .predict_with_interval(&x_future, Some(IntervalType::Prediction), level);
+
+            let values: Vec<f64> = pred_result.fit.iter().copied().collect();
+            let lower: Vec<f64> = pred_result.lower.iter().copied().collect();
+            let upper: Vec<f64> = pred_result.upper.iter().copied().collect();
+
+            // If intervals contain NaN (e.g. xtx_inverse unavailable for
+            // a non-linear backend), return point-only — avoids
+            // misleading callers with phantom CIs.
+            if lower.iter().any(|v| v.is_nan()) || upper.iter().any(|v| v.is_nan()) {
+                return Ok(Forecast::from_values(values));
+            }
+
+            Ok(Forecast::from_values_with_intervals(values, lower, upper))
+        }
+
         fn fitted_values(&self) -> Option<&[f64]> {
             self.state.as_ref().map(|s| s.fitted_values.as_slice())
         }
@@ -4157,6 +4245,107 @@ mod ols_impl {
             future_regs.insert("temperature".to_string(), future_x);
             let forecast = model_exog.predict_with_exog(5, &future_regs).unwrap();
             assert_eq!(forecast.primary().len(), 5);
+        }
+
+        #[test]
+        fn predict_with_exog_intervals_returns_finite_bounds() {
+            // Issue #123: exog-fit OLS models must surface prediction
+            // intervals via predict_with_exog_intervals(). Lag-free
+            // direct forecasts (the only case where OLS PIs are valid)
+            // should return finite lower/upper bounds bracketing the
+            // point estimate.
+            let n = 80;
+            let x_vals: Vec<f64> = (0..n).map(|i| (i as f64 * 0.3).sin()).collect();
+            let values: Vec<f64> = (0..n)
+                .map(|i| 3.0 * x_vals[i] + 5.0 + 0.1 * i as f64)
+                .collect();
+            let cal = CalendarAnnotations::new()
+                .with_regressor("temperature".to_string(), x_vals.clone());
+            let ts = TimeSeriesBuilder::new()
+                .timestamps(make_timestamps(n))
+                .values(values)
+                .calendar(cal)
+                .build()
+                .unwrap();
+
+            // Lag-free OLS regression with one exog column.
+            let mut model = RegressionForecaster::ols(RegressionFeatures::new().trend());
+            model.fit(&ts).unwrap();
+
+            let future_x: Vec<f64> = (n..n + 5).map(|i| (i as f64 * 0.3).sin()).collect();
+            let mut future_regs = HashMap::new();
+            future_regs.insert("temperature".to_string(), future_x);
+
+            let forecast = model
+                .predict_with_exog_intervals(5, &future_regs, 0.95)
+                .unwrap();
+            assert_eq!(forecast.primary().len(), 5);
+
+            let lower = forecast.lower_series(0).expect("lower bound present");
+            let upper = forecast.upper_series(0).expect("upper bound present");
+            let point = forecast.primary();
+
+            for h in 0..5 {
+                assert!(
+                    lower[h].is_finite(),
+                    "lower[{}] not finite: {}",
+                    h,
+                    lower[h]
+                );
+                assert!(
+                    upper[h].is_finite(),
+                    "upper[{}] not finite: {}",
+                    h,
+                    upper[h]
+                );
+                assert!(
+                    point[h].is_finite(),
+                    "point[{}] not finite: {}",
+                    h,
+                    point[h]
+                );
+                assert!(
+                    lower[h] <= point[h] && point[h] <= upper[h],
+                    "point {} not bracketed by [{}, {}] at h={}",
+                    point[h],
+                    lower[h],
+                    upper[h],
+                    h
+                );
+            }
+        }
+
+        #[test]
+        fn predict_with_exog_intervals_falls_back_to_points_on_recursive() {
+            // Models with lags can't use direct OLS PIs — must fall
+            // back to points (same contract as predict_with_intervals
+            // on no-exog recursive models).
+            let n = 80;
+            let x_vals: Vec<f64> = (0..n).map(|i| (i as f64 * 0.3).sin()).collect();
+            let values: Vec<f64> = (0..n).map(|i| 2.0 * x_vals[i] + 0.05 * i as f64).collect();
+            let cal = CalendarAnnotations::new().with_regressor("x".to_string(), x_vals);
+            let ts = TimeSeriesBuilder::new()
+                .timestamps(make_timestamps(n))
+                .values(values)
+                .calendar(cal)
+                .build()
+                .unwrap();
+            let mut model = RegressionForecaster::ols(
+                RegressionFeatures::new().trend().lags(2), // recursive
+            );
+            model.fit(&ts).unwrap();
+
+            let future_x: Vec<f64> = (n..n + 5).map(|i| (i as f64 * 0.3).sin()).collect();
+            let mut future_regs = HashMap::new();
+            future_regs.insert("x".to_string(), future_x);
+
+            let forecast = model
+                .predict_with_exog_intervals(5, &future_regs, 0.95)
+                .unwrap();
+            // Recursive → falls back to points, no lower/upper bounds.
+            assert_eq!(forecast.primary().len(), 5);
+            assert!(forecast.lower().is_none());
+            assert!(forecast.upper().is_none());
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Patch release **0.8.6 → 0.8.7** bundling two small additive features. Both purely additive — no breaking changes.

### Issue #93 — Levenbach STI_Class taxonomy

New module `forecastability::sti_class`. Classifies a monthly series into one of six categories by ranking the relative magnitude of Seasonal / Trend / Irregular mean-squares from a two-way ANOVA without replication on a `years × months` grid.

```rust
use anofox_forecast::forecastability::{sti_class, StiClass};

let result = sti_class(&monthly_values, 12, 5)?;
match result.class {
    StiClass::Sti | StiClass::Sit => /* seasonal-dominant */,
    StiClass::Tsi | StiClass::Tis => /* trend-dominant */,
    StiClass::Ist | StiClass::Its => /* irregular-dominant */,
}
```

Honest limitations documented: monthly only (M5 daily collapses to one class); under pure white noise the class is statistically random because all MS are equal in expectation. Gated behind the `forecastability` feature.

### Issue #123 — `predict_with_exog_intervals`

Overrides the `Forecaster` trait's default points-only impl on `RegressionForecaster` to surface true OLS / WLS prediction intervals through the exog future-design matrix.

```rust
let mut model = RegressionForecaster::ols(RegressionFeatures::new().trend());
model.fit(&ts)?;
let forecast = model.predict_with_exog_intervals(5, &future_regs, 0.95)?;
let lower = forecast.lower_series(0)?;
let upper = forecast.upper_series(0)?;
```

Unblocks the orchestrator metalearner that was emitting NaN `forecast_q*` for ~42% of rows on regression-family methods (anofox-orchestration#165, Kärcher 569k-series cutover). Recursive (lag-using) models fall back to point-only — same contract as `predict_with_intervals`, since direct OLS PIs don't apply to recursive forecasts.

## Version bumps

- `Cargo.toml`: 0.8.6 → 0.8.7
- `crates/anofox-forecast-js/Cargo.toml`: 0.8.6 → 0.8.7
- `crates/anofox-forecast-js/package.json`: 0.8.6 → 0.8.7
- `js/package.json`: 0.8.6 → 0.8.7
- `Cargo.lock`: regenerated
- `README.md`: install snippet
- `CHANGELOG.md`: new `[0.8.7]` entry covering both fixes

## Test plan

- [x] `cargo test --lib --features \"serde forecastability\"` — 2965 passed (+11 since 0.8.6: 9 STI_Class + 2 exog-intervals)
- [x] New tests:
  - 9 STI_Class tests (pure seasonal / trend / noise / degenerate)
  - 2 `predict_with_exog_intervals` tests (finite bounded interval on lag-free; fallback to points on recursive)
- [x] All integration suites still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)