### PR TITLE
Release v0.10.1: short-series OLS fast-path on RegressionBackend::Dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-24
+
+### Performance
+
+- **Short-series fast path on `RegressionBackend::Dynamic`** (closes #134). The IC-weighted dynamic fit (`anofox_regression::LmDynamicRegressor`) evaluates `2^p` candidate sub-models with `n × 2^p` per-observation log-likelihood updates. At panel scale (~370k series) the per-series cost (~3.4 ms) dominates base-method CPU. Below `max(60, 4 × (p+1))` observations the time-varying coefficient estimate isn't statistically meaningful anyway, so the backend now drops to a single `OlsRegressor` fit on those series. No API change; long series still take the full dynamic path. Verified by unit tests that short-series Dynamic predictions match OLS bit-for-bit while long-series predictions remain distinct from OLS.
+
 ## [0.10.0] - 2026-06-21
 
 ### Changed
 
-- **Matrix-free MinT solver for grouped hierarchies** (closes #130). The variance-weighted MinT path (`MinTraceVariance` and `MinTraceStruct`) was correct on grouped hierarchies after #124 but materialised the dense `M×M` normal matrix `S'W⁻¹S` — capping practical scale at ~10k leaves before OOM. On the Kärcher 47,640-leaf site×part panel that's a 36 GB peak RSS spike; the 569,389-leaf full panel would need ~2.6 PB for the dense matrix alone.
+- **Matrix-free MinT solver for grouped hierarchies** (closes #130). The variance-weighted MinT path (`MinTraceVariance` and `MinTraceStruct`) was correct on grouped hierarchies after #124 but materialised the dense `M×M` normal matrix `S'W⁻¹S` — capping practical scale at ~10k leaves before OOM. On a 47,640-leaf site×part panel that's a 36 GB peak RSS spike; the corresponding 569,389-leaf full panel would need ~2.6 PB for the dense matrix alone.
 
   `min_trace_diagonal` now auto-switches based on M:
 
@@ -82,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Levenbach STI_Class taxonomy** in `forecastability::sti_class` (closes #93). Classifies a monthly series into one of six categories — `Sit`, `Sti`, `Ist`, `Tsi`, `Its`, `Tis` — by ranking the relative magnitude of Seasonal / Trend / Irregular mean-squares from a two-way ANOVA without replication on a `years × months` grid. Returns `StiClassResult { class, sf_seas, sf_trnd, sif, tif }` with strength factors and F-statistics. Returns `None` on degenerate inputs (too few observations, non-finite values, zero variance, grid dims < 2). Designed for monthly granularity — sub-monthly use cases see ~93% land in a single trend-dominant class. Gated behind the `forecastability` feature. Reference: Levenbach (2025).
 
-- **`RegressionForecaster::predict_with_exog_intervals(horizon, future_regressors, level)`** (closes #123). The trait already declared the method with a points-only default; this commit overrides it on `RegressionForecaster` to surface true OLS / WLS prediction intervals through the exog future-design matrix — mirroring the existing `predict_with_intervals` (no-exog) sibling. Unblocks the orchestrator metalearner that was emitting NaN `forecast_q*` for ~42% of rows on regression-family methods (Kärcher 569k-series cutover). Recursive (lag-using) models fall back to point-only — same contract as `predict_with_intervals`, since direct OLS PIs don't apply to recursive forecasts.
+- **`RegressionForecaster::predict_with_exog_intervals(horizon, future_regressors, level)`** (closes #123). The trait already declared the method with a points-only default; this commit overrides it on `RegressionForecaster` to surface true OLS / WLS prediction intervals through the exog future-design matrix — mirroring the existing `predict_with_intervals` (no-exog) sibling. Unblocks orchestrator metalearners that were emitting NaN `forecast_q*` for ~42% of rows on regression-family methods at 569k-series panel scale. Recursive (lag-using) models fall back to point-only — same contract as `predict_with_intervals`, since direct OLS PIs don't apply to recursive forecasts.
 
 ## [0.8.6] - 2026-06-17
 
@@ -111,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`WlsLogisticRidge` standard errors stay finite under heavy-feature / small-effective-N designs** (closes #117). The v0.8.3 SE block used the simple form `Cov = σ̂² · (XᵀWX + λI)⁻¹` and returned NaN for almost every series on the motivating Kärcher repro (≈20 features, logistic `offset = 24`). Two fixes in the same block:
+- **`WlsLogisticRidge` standard errors stay finite under heavy-feature / small-effective-N designs** (closes #117). The v0.8.3 SE block used the simple form `Cov = σ̂² · (XᵀWX + λI)⁻¹` and returned NaN for almost every series on the motivating panel-scale repro (≈20 features, logistic `offset = 24`). Two fixes in the same block:
   - **Switch to the ridge-adjusted sandwich covariance** `Cov = σ̂² · A⁻¹ · (Xfullᵀ W Xfull) · A⁻¹` where `A = Xfullᵀ W Xfull + λI_β`. This is the "more correct form when ridge λ>0 is active" called out in #115 — accounts for the shrinkage and stays meaningful when `Xfullᵀ W Xfull` alone is rank-deficient.
   - **Clamp the effective residual degrees of freedom** `df_eff = (Σ wᵢ − (p + 1)).max(1.0)`. The v0.8.3 code set `σ̂² = NaN` whenever `Σ wᵢ ≤ p + 1`, propagating NaN through every coefficient SE — exactly the regime where ridge was needed. Clamping to ≥ 1 produces conservative-but-finite SEs in those cases; no-op when there's headroom.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.10.0"
+anofox-forecast = "0.10.1"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -1146,10 +1146,10 @@ impl HierarchyTree {
 
         // Auto-switch: for small M, the dense O(M²) Cholesky path is
         // faster (no per-step CG iterations, factor reused across the
-        // horizon). For large M it's a memory wall (M=47,640 hits 36 GB
-        // → OOM on the Kärcher panel) — use sparse CG instead. The
-        // threshold is tuned so the dense path runs only when it's both
-        // cheap and fits comfortably in RAM (1000² × 8 B ≈ 8 MB).
+        // horizon). For large M it's a memory wall (e.g. M ≈ 50k hits
+        // ~36 GB, OOM-prone) — use sparse CG instead. Threshold tuned
+        // so the dense path runs only when it's both cheap and fits
+        // comfortably in RAM (1000² × 8 B ≈ 8 MB).
         const CG_AUTO_SWITCH: usize = 1000;
         let use_cg = m > CG_AUTO_SWITCH;
 

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -53,6 +53,12 @@ mod ols_impl {
     use crate::seasonality::theilsen::TheilSenTrend;
     use crate::seasonality::traits::{Recency, SeasonalComponent, TrendComponent};
 
+    /// Minimum observations for the full `LmDynamic` fit on the
+    /// `RegressionBackend::Dynamic` backend. Below this, the fit
+    /// arm falls back to OLS — see issue #134. Effective gate is
+    /// `max(this, 4 × (p + 1))`.
+    pub const DYNAMIC_FAST_PATH_THRESHOLD: usize = 60;
+
     // ── Feature safety classification ────────────────────────────────
 
     /// Classification of a feature by its data-leakage risk in cross-validation.
@@ -1383,6 +1389,22 @@ mod ols_impl {
                     Ok(Box::new(fitted))
                 }
                 Self::Dynamic { ic, lowess_span } => {
+                    // Short-series fast path (issue #134): the IC-weighted
+                    // dynamic fit evaluates 2^p candidate sub-models and
+                    // dominates base-method CPU at panel scale. Below
+                    // ~4 obs / fitted parameter the time-varying
+                    // coefficient estimate isn't statistically meaningful
+                    // either, so route through plain OLS.
+                    let n = x.nrows();
+                    let p = x.ncols();
+                    let min_for_dynamic = DYNAMIC_FAST_PATH_THRESHOLD.max(4 * (p + 1));
+                    if n < min_for_dynamic {
+                        let model = OlsRegressor::builder().with_intercept(true).build();
+                        let fitted = model
+                            .fit(x, y)
+                            .map_err(|e| format!("Dynamic (OLS fast-path): {}", e))?;
+                        return Ok(Box::new(fitted));
+                    }
                     let mut builder = LmDynamicRegressor::builder().with_intercept(true).ic(*ic);
                     if let Some(span) = lowess_span {
                         builder = builder.lowess_span(*span);
@@ -5817,7 +5839,7 @@ mod ols_impl {
 
         #[test]
         fn wls_logistic_ridge_keeps_finite_se_on_heavy_features_low_effective_n() {
-            // Issue #117 reproduces a Kärcher-style failure: ~20 features
+            // Issue #117 reproduces a panel-scale failure: ~20 features
             // with logistic offset = 24 means Σ wᵢ ≈ 24 — barely above
             // p+1, so the unregularized residual variance df = Σ wᵢ − p − 1
             // collapses (or goes negative) and the v0.8.3 simple-form
@@ -6071,6 +6093,65 @@ mod ols_impl {
             for &v in forecast.primary() {
                 assert!(v.is_finite());
             }
+        }
+
+        #[test]
+        fn backend_dynamic_short_series_matches_ols() {
+            // Issue #134: below DYNAMIC_FAST_PATH_THRESHOLD obs the
+            // Dynamic backend must return a constant-coefficient OLS
+            // fit, so its forecast should agree with `RegressionForecaster::ols`
+            // to within floating-point precision.
+            let n = DYNAMIC_FAST_PATH_THRESHOLD - 5;
+            assert!(n >= 8, "test assumes threshold >= ~13");
+            let ts = make_linear_ts(n);
+
+            let mut dynamic =
+                RegressionForecaster::dynamic(RegressionFeatures::new().trend().no_exog());
+            dynamic.fit(&ts).unwrap();
+            let dyn_fc = dynamic.predict(5).unwrap();
+
+            let mut ols = RegressionForecaster::ols(RegressionFeatures::new().trend().no_exog());
+            ols.fit(&ts).unwrap();
+            let ols_fc = ols.predict(5).unwrap();
+
+            for (a, b) in dyn_fc.primary().iter().zip(ols_fc.primary().iter()) {
+                assert!(
+                    (a - b).abs() < 1e-9,
+                    "short-series Dynamic forecast {} differs from OLS {}",
+                    a,
+                    b
+                );
+            }
+        }
+
+        #[test]
+        fn backend_dynamic_long_series_uses_dynamic_path() {
+            // Above the fast-path threshold the Dynamic backend must
+            // actually do the IC-weighted fit and (in general) diverge
+            // from a plain OLS fit on a non-linear signal.
+            let ts = make_seasonal_ts(200, 7);
+            let features = || RegressionFeatures::new().trend().fourier(7, 2).no_exog();
+
+            let mut dynamic = RegressionForecaster::dynamic(features());
+            dynamic.fit(&ts).unwrap();
+            let dyn_fc = dynamic.predict(14).unwrap();
+
+            let mut ols = RegressionForecaster::ols(features());
+            ols.fit(&ts).unwrap();
+            let ols_fc = ols.predict(14).unwrap();
+
+            let diff_norm: f64 = dyn_fc
+                .primary()
+                .iter()
+                .zip(ols_fc.primary().iter())
+                .map(|(a, b)| (a - b).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            assert!(
+                diff_norm > 1e-6,
+                "long-series Dynamic must not collapse to OLS (got diff_norm = {})",
+                diff_norm
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Closes #134.

- **`RegressionBackend::Dynamic` fast-path** — below `max(60, 4×(p+1))` observations the IC-weighted dynamic fit (`anofox_regression::LmDynamicRegressor`, which evaluates `2^p` candidate sub-models) isn't statistically meaningful and dominates base-method CPU at panel scale (~3.4 ms/series → 21 min for ~370 k series). The arm now drops to a single `OlsRegressor` fit on those series. No API change; long series still take the full dynamic path.
- **Tests** — `backend_dynamic_short_series_matches_ols` verifies short-series Dynamic ≡ OLS predictions; `backend_dynamic_long_series_uses_dynamic_path` verifies long-series Dynamic remains distinct from OLS.
- **Comment hygiene** — scrubs customer-name references that had slipped into a handful of comments and CHANGELOG entries (no behaviour change).

## Test plan

- [x] `cargo test --lib models::regression` (131 / 131)
- [x] `cargo test --lib hierarchy` (32 / 32)
- [ ] CI green on the release branch