### PR TITLE
Release v0.10.2: make Dynamic short-series OLS fast-path opt-in (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-06-24
+
+### Fixed
+
+- **Restore default `RegressionBackend::Dynamic` behaviour; make the v0.10.1 short-series OLS fast-path opt-in** (closes #137). v0.10.1 enabled the fast-path unconditionally and traded a real win — MAE-neutral, ~11× faster — for a downstream-measured **+24% rise in delivered median |bias|** on a 367k-series panel: short-series DynLM was the low-bias method (win-rate 24.8% on v0.10.0), and the fast path silently replaced it with OLS. Point accuracy (MAE) was unchanged, but bias regressed.
+
+  v0.10.2 reverts `RegressionForecaster::dynamic` / `dynamic_smoothed` to the full IC-weighted fit on every series — bit-for-bit the same behaviour as v0.10.0. Callers who measured the perf/bias trade-off and want the fast path can opt in via the new `dynamic_fast` / `dynamic_smoothed_fast` constructors.
+
+  The `RegressionBackend::Dynamic` variant gained a `short_series_ols_fast_path: bool` field (struct-literal callers must initialise it; convenience constructors handle it for you).
+
 ## [0.10.1] - 2026-06-24
 
 ### Performance
 
-- **Short-series fast path on `RegressionBackend::Dynamic`** (closes #134). The IC-weighted dynamic fit (`anofox_regression::LmDynamicRegressor`) evaluates `2^p` candidate sub-models with `n × 2^p` per-observation log-likelihood updates. At panel scale (~370k series) the per-series cost (~3.4 ms) dominates base-method CPU. Below `max(60, 4 × (p+1))` observations the time-varying coefficient estimate isn't statistically meaningful anyway, so the backend now drops to a single `OlsRegressor` fit on those series. No API change; long series still take the full dynamic path. Verified by unit tests that short-series Dynamic predictions match OLS bit-for-bit while long-series predictions remain distinct from OLS.
+- **Short-series fast path on `RegressionBackend::Dynamic`** (closes #134). Below `max(60, 4 × (p+1))` observations the backend drops to a single `OlsRegressor` fit; long series take the full dynamic path. **Superseded by #137 in v0.10.2**: the fast-path is now opt-in via `dynamic_fast` / `dynamic_smoothed_fast` because the default-on behaviour shipped here caused a +24% delivered-bias regression at panel scale.
 
 ## [0.10.0] - 2026-06-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.10.1"
+anofox-forecast = "0.10.2"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -1049,6 +1049,15 @@ mod ols_impl {
             ic: InformationCriterion,
             /// LOWESS smoothing span for weights (None = no smoothing).
             lowess_span: Option<f64>,
+            /// If `true`, short series (n < max(60, 4·(p+1))) are fit
+            /// with plain OLS instead of the full IC-weighted dynamic
+            /// procedure. Off by default — see issue #137: the fast
+            /// path makes the backend ~11× faster but drops the
+            /// low-bias behaviour the dynamic fit normally contributes,
+            /// raising delivered median |bias| ~24% on real panels.
+            /// Opt in only when the caller has measured that the perf
+            /// gain is worth the bias trade-off.
+            short_series_ols_fast_path: bool,
         },
     }
 
@@ -1388,22 +1397,33 @@ mod ols_impl {
                     let fitted = model.fit(x, y).map_err(|e| format!("BLS: {}", e))?;
                     Ok(Box::new(fitted))
                 }
-                Self::Dynamic { ic, lowess_span } => {
-                    // Short-series fast path (issue #134): the IC-weighted
-                    // dynamic fit evaluates 2^p candidate sub-models and
-                    // dominates base-method CPU at panel scale. Below
-                    // ~4 obs / fitted parameter the time-varying
-                    // coefficient estimate isn't statistically meaningful
-                    // either, so route through plain OLS.
-                    let n = x.nrows();
-                    let p = x.ncols();
-                    let min_for_dynamic = DYNAMIC_FAST_PATH_THRESHOLD.max(4 * (p + 1));
-                    if n < min_for_dynamic {
-                        let model = OlsRegressor::builder().with_intercept(true).build();
-                        let fitted = model
-                            .fit(x, y)
-                            .map_err(|e| format!("Dynamic (OLS fast-path): {}", e))?;
-                        return Ok(Box::new(fitted));
+                Self::Dynamic {
+                    ic,
+                    lowess_span,
+                    short_series_ols_fast_path,
+                } => {
+                    // Issue #134 / #137: the IC-weighted dynamic fit
+                    // evaluates 2^p candidate sub-models and dominates
+                    // base-method CPU at panel scale. Below ~4 obs /
+                    // fitted parameter the dynamic coefficients aren't
+                    // statistically meaningful either. v0.10.1 shipped
+                    // this fast path on by default — but it drops the
+                    // low-bias behaviour the dynamic fit contributes,
+                    // not just its (already-tied) point accuracy. So
+                    // the path is now opt-in; callers who measured the
+                    // trade-off can enable it via `dynamic_fast()` /
+                    // `dynamic_smoothed_fast()`.
+                    if *short_series_ols_fast_path {
+                        let n = x.nrows();
+                        let p = x.ncols();
+                        let min_for_dynamic = DYNAMIC_FAST_PATH_THRESHOLD.max(4 * (p + 1));
+                        if n < min_for_dynamic {
+                            let model = OlsRegressor::builder().with_intercept(true).build();
+                            let fitted = model
+                                .fit(x, y)
+                                .map_err(|e| format!("Dynamic (OLS fast-path): {}", e))?;
+                            return Ok(Box::new(fitted));
+                        }
                     }
                     let mut builder = LmDynamicRegressor::builder().with_intercept(true).ic(*ic);
                     if let Some(span) = lowess_span {
@@ -3428,22 +3448,64 @@ mod ols_impl {
         /// Automatically generates candidate models from variable subsets and
         /// computes observation-level IC weights. Use `lowess_span` to smooth
         /// the weights over time (e.g., 0.3), or `None` for no smoothing.
+        ///
+        /// The full IC-weighted fit is used on every series. For the
+        /// short-series OLS fast-path (~11× faster but raises delivered
+        /// median |bias|, see issue #137), use [`dynamic_fast`].
         pub fn dynamic(features: RegressionFeatures) -> Self {
             Self::new(
                 RegressionBackend::Dynamic {
                     ic: InformationCriterion::AICc,
                     lowess_span: None,
+                    short_series_ols_fast_path: false,
                 },
                 features,
             )
         }
 
         /// Create a Dynamic Linear Model with LOWESS-smoothed weights.
+        ///
+        /// Full IC-weighted fit on every series; opt into the
+        /// short-series OLS fast-path via [`dynamic_smoothed_fast`].
         pub fn dynamic_smoothed(lowess_span: f64, features: RegressionFeatures) -> Self {
             Self::new(
                 RegressionBackend::Dynamic {
                     ic: InformationCriterion::AICc,
                     lowess_span: Some(lowess_span),
+                    short_series_ols_fast_path: false,
+                },
+                features,
+            )
+        }
+
+        /// Like [`dynamic`] but with the short-series OLS fast-path on:
+        /// series with `n < max(60, 4·(p+1))` observations are fit
+        /// with plain OLS instead of the full IC-weighted procedure.
+        ///
+        /// Roughly 11× faster on panel-scale workloads (see #134), but
+        /// drops the low-bias contribution the dynamic fit normally
+        /// makes on short series — measured at +24% delivered median
+        /// |bias| in panel A/B testing (see #137). Choose this only
+        /// when point accuracy matters more than bias.
+        pub fn dynamic_fast(features: RegressionFeatures) -> Self {
+            Self::new(
+                RegressionBackend::Dynamic {
+                    ic: InformationCriterion::AICc,
+                    lowess_span: None,
+                    short_series_ols_fast_path: true,
+                },
+                features,
+            )
+        }
+
+        /// Like [`dynamic_smoothed`] but with the short-series OLS
+        /// fast-path on. Same trade-off as [`dynamic_fast`].
+        pub fn dynamic_smoothed_fast(lowess_span: f64, features: RegressionFeatures) -> Self {
+            Self::new(
+                RegressionBackend::Dynamic {
+                    ic: InformationCriterion::AICc,
+                    lowess_span: Some(lowess_span),
+                    short_series_ols_fast_path: true,
                 },
                 features,
             )
@@ -6096,17 +6158,18 @@ mod ols_impl {
         }
 
         #[test]
-        fn backend_dynamic_short_series_matches_ols() {
-            // Issue #134: below DYNAMIC_FAST_PATH_THRESHOLD obs the
-            // Dynamic backend must return a constant-coefficient OLS
-            // fit, so its forecast should agree with `RegressionForecaster::ols`
-            // to within floating-point precision.
+        fn backend_dynamic_fast_short_series_matches_ols() {
+            // Issue #134 + #137: when the caller explicitly opts in
+            // via `dynamic_fast`, short series collapse to a constant-
+            // coefficient OLS fit, so the forecast should agree with
+            // `RegressionForecaster::ols` to within floating-point
+            // precision.
             let n = DYNAMIC_FAST_PATH_THRESHOLD - 5;
             assert!(n >= 8, "test assumes threshold >= ~13");
             let ts = make_linear_ts(n);
 
             let mut dynamic =
-                RegressionForecaster::dynamic(RegressionFeatures::new().trend().no_exog());
+                RegressionForecaster::dynamic_fast(RegressionFeatures::new().trend().no_exog());
             dynamic.fit(&ts).unwrap();
             let dyn_fc = dynamic.predict(5).unwrap();
 
@@ -6117,11 +6180,44 @@ mod ols_impl {
             for (a, b) in dyn_fc.primary().iter().zip(ols_fc.primary().iter()) {
                 assert!(
                     (a - b).abs() < 1e-9,
-                    "short-series Dynamic forecast {} differs from OLS {}",
+                    "short-series dynamic_fast forecast {} differs from OLS {}",
                     a,
                     b
                 );
             }
+        }
+
+        #[test]
+        fn backend_dynamic_default_keeps_full_fit_on_short_series() {
+            // Issue #137: the default `dynamic()` constructor must
+            // NOT fall through to OLS on short series — that was the
+            // v0.10.1 regression. Use a noisy seasonal signal where
+            // OLS and the IC-weighted dynamic fit demonstrably diverge.
+            let n = DYNAMIC_FAST_PATH_THRESHOLD - 5;
+            let ts = make_seasonal_ts(n, 7);
+            let features = || RegressionFeatures::new().trend().fourier(7, 2).no_exog();
+
+            let mut dynamic = RegressionForecaster::dynamic(features());
+            dynamic.fit(&ts).unwrap();
+            let dyn_fc = dynamic.predict(7).unwrap();
+
+            let mut ols = RegressionForecaster::ols(features());
+            ols.fit(&ts).unwrap();
+            let ols_fc = ols.predict(7).unwrap();
+
+            let diff_norm: f64 = dyn_fc
+                .primary()
+                .iter()
+                .zip(ols_fc.primary().iter())
+                .map(|(a, b)| (a - b).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            assert!(
+                diff_norm > 1e-6,
+                "default dynamic() on short series must NOT collapse to OLS \
+                 (diff_norm = {} — fast path leaked into the default constructor)",
+                diff_norm
+            );
         }
 
         #[test]

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -3451,7 +3451,7 @@ mod ols_impl {
         ///
         /// The full IC-weighted fit is used on every series. For the
         /// short-series OLS fast-path (~11× faster but raises delivered
-        /// median |bias|, see issue #137), use [`dynamic_fast`].
+        /// median |bias|, see issue #137), use [`Self::dynamic_fast`].
         pub fn dynamic(features: RegressionFeatures) -> Self {
             Self::new(
                 RegressionBackend::Dynamic {
@@ -3466,7 +3466,7 @@ mod ols_impl {
         /// Create a Dynamic Linear Model with LOWESS-smoothed weights.
         ///
         /// Full IC-weighted fit on every series; opt into the
-        /// short-series OLS fast-path via [`dynamic_smoothed_fast`].
+        /// short-series OLS fast-path via [`Self::dynamic_smoothed_fast`].
         pub fn dynamic_smoothed(lowess_span: f64, features: RegressionFeatures) -> Self {
             Self::new(
                 RegressionBackend::Dynamic {
@@ -3478,7 +3478,7 @@ mod ols_impl {
             )
         }
 
-        /// Like [`dynamic`] but with the short-series OLS fast-path on:
+        /// Like [`Self::dynamic`] but with the short-series OLS fast-path on:
         /// series with `n < max(60, 4·(p+1))` observations are fit
         /// with plain OLS instead of the full IC-weighted procedure.
         ///
@@ -3498,8 +3498,8 @@ mod ols_impl {
             )
         }
 
-        /// Like [`dynamic_smoothed`] but with the short-series OLS
-        /// fast-path on. Same trade-off as [`dynamic_fast`].
+        /// Like [`Self::dynamic_smoothed`] but with the short-series OLS
+        /// fast-path on. Same trade-off as [`Self::dynamic_fast`].
         pub fn dynamic_smoothed_fast(lowess_span: f64, features: RegressionFeatures) -> Self {
             Self::new(
                 RegressionBackend::Dynamic {


### PR DESCRIPTION
## Summary

Closes #137. Reverts the v0.10.1 default-on behaviour for the `RegressionBackend::Dynamic` short-series OLS fast-path.

v0.10.1 traded a real win — MAE-neutral, ~11× faster on `RegressionForecaster::dynamic` (closes #134) — for a **+24% rise in delivered median |bias|** on a 367k-series panel. The dynamic fit on short series was the low-bias method (win-rate 24.8% on v0.10.0 → 2.47% on v0.10.1), and silently dropping it to OLS replaced the bias contribution without anything taking its place.

### Changes

- `RegressionForecaster::dynamic` / `dynamic_smoothed` → full IC-weighted fit on every series (bit-for-bit v0.10.0 behaviour).
- New opt-in constructors `dynamic_fast` / `dynamic_smoothed_fast` for callers who measured the perf/bias trade-off and want the shortcut.
- `RegressionBackend::Dynamic` variant gained a `short_series_ols_fast_path: bool` field. Struct-literal callers must initialise it; the convenience constructors handle it.

### Tests

- New `backend_dynamic_default_keeps_full_fit_on_short_series` is the regression guard: on a short, noisy seasonal signal the default `dynamic()` forecast must differ from a plain OLS fit. If the fast-path ever leaks into the default again this fails.
- Updated `backend_dynamic_fast_short_series_matches_ols` (the v0.10.1 test, retargeted to the explicit `dynamic_fast` constructor): short-series `dynamic_fast` ≡ OLS to floating-point precision.
- `backend_dynamic_long_series_uses_dynamic_path`: unchanged, still asserts the long-series default goes through the IC-weighted path.

## Test plan

- [x] `cargo test --lib` — 2871 / 2871 pass
- [ ] CI green on the release branch