### PR TITLE
Release v0.11.0: Forecaster::explanation() reads fitted params without re-fitting (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-26
+
+### Added
+
+- **`Forecaster::explanation()` reads fitted params without re-fitting** (closes #136). The trait gained a default `fn explanation(&self) -> Result<Explanation>` (default returns `Err(InvalidParameter)`). Every model that already implements `Inspectable` now overrides it with a one-line delegate: `RegressionForecaster`, `AutoARIMA`, `AutoETS`, `AutoTheta`, `AutoTBATS`, `MFLES`, `MSTLForecaster`. Callers holding `Box<dyn Forecaster>` can now read `model.explanation()` directly — no second-trait bound, no downcast, no re-fit. Downstream `model_params` extraction was previously paying the entire per-series fit cost a second time (~178 s of a 185 s output stage on a 6,319-series / 7-method panel; projected to ~2.9 h on a 367k-series panel); the extra fit goes away once callers route through the trait method.
+- The standalone `Inspectable` trait is kept as-is — the new `Forecaster::explanation` delegates to it, so existing direct uses continue to work. No deprecation.
+
+### Migration
+
+Additive change, backward-compatible. Existing code that imports `Inspectable` and calls `model.explanation()` on a concrete model may hit `E0034` (multiple methods named `explanation`); drop the `Inspectable` import — `Forecaster::explanation` is in scope wherever the model is fit, and delegates to `Inspectable`.
+
 ## [0.10.2] - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.10.2"
+anofox-forecast = "0.11.0"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/arima/auto_arima.rs
+++ b/src/models/arima/auto_arima.rs
@@ -1031,6 +1031,10 @@ impl Forecaster for AutoARIMA {
         }
     }
 
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
+
     fn supports_exog(&self) -> bool {
         true
     }

--- a/src/models/exponential/auto_ets.rs
+++ b/src/models/exponential/auto_ets.rs
@@ -614,6 +614,10 @@ impl Forecaster for AutoETS {
         "AutoETS"
     }
 
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
+
     fn supports_exog(&self) -> bool {
         true
     }

--- a/src/models/mfles.rs
+++ b/src/models/mfles.rs
@@ -1568,6 +1568,10 @@ impl Forecaster for MFLES {
     fn name(&self) -> &str {
         "MFLES"
     }
+
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
 }
 
 impl Inspectable for MFLES {

--- a/src/models/mstl_forecaster.rs
+++ b/src/models/mstl_forecaster.rs
@@ -628,6 +628,10 @@ impl Forecaster for MSTLForecaster {
         "MSTLForecaster"
     }
 
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
+
     fn supports_exog(&self) -> bool {
         true
     }

--- a/src/models/regression.rs
+++ b/src/models/regression.rs
@@ -4066,6 +4066,10 @@ mod ols_impl {
         fn name(&self) -> &str {
             self.backend.name()
         }
+
+        fn explanation(&self) -> Result<crate::models::inspect::Explanation> {
+            <Self as crate::models::inspect::Inspectable>::explanation(self)
+        }
     }
 
     impl crate::models::inspect::Inspectable for RegressionForecaster {
@@ -4139,7 +4143,7 @@ mod ols_impl {
 
         #[test]
         fn inspectable_linear_trend_returns_regression_explanation() {
-            use crate::models::inspect::{Explanation, Inspectable};
+            use crate::models::inspect::Explanation;
 
             let ts = make_linear_ts(40);
             let mut model = RegressionForecaster::linear_trend();
@@ -4166,8 +4170,59 @@ mod ols_impl {
         }
 
         #[test]
+        fn boxed_forecaster_exposes_explanation_without_refitting() {
+            // Issue #136: callers holding `Box<dyn Forecaster>` can read
+            // the fit's coefficients through `Forecaster::explanation()`
+            // without bounding on `Inspectable` or downcasting — and,
+            // because the override delegates to cached state, repeated
+            // calls do not re-fit.
+            use crate::models::inspect::Explanation;
+            use crate::models::traits::Forecaster;
+
+            let ts = make_linear_ts(40);
+            let mut model: Box<dyn Forecaster> = Box::new(RegressionForecaster::linear_trend());
+
+            assert!(
+                matches!(model.explanation(), Err(ForecastError::FitRequired { .. })),
+                "Box<dyn Forecaster>::explanation() before fit must return FitRequired"
+            );
+
+            model.fit(&ts).unwrap();
+
+            let first = model.explanation().unwrap();
+            let second = model.explanation().unwrap();
+
+            let (Explanation::Regression(a), Explanation::Regression(b)) = (first, second) else {
+                panic!("expected Explanation::Regression");
+            };
+            assert_eq!(
+                a.coefficients, b.coefficients,
+                "repeated explanation() must return identical coefficients \
+                 (would diverge if it silently re-fit on noisy iterative backends)"
+            );
+            assert_eq!(a.r_squared, b.r_squared);
+        }
+
+        #[test]
+        fn boxed_forecaster_explanation_unsupported_default_errs() {
+            // The default impl on Forecaster returns
+            // InvalidParameter for models without an Inspectable
+            // override. Sanity check the trait wiring.
+            use crate::models::baseline::Naive;
+            use crate::models::traits::Forecaster;
+
+            let ts = make_linear_ts(20);
+            let mut naive: Box<dyn Forecaster> = Box::new(Naive::new());
+            naive.fit(&ts).unwrap();
+            assert!(
+                matches!(naive.explanation(), Err(ForecastError::InvalidParameter(_))),
+                "Naive must use the default `explanation()` Err path"
+            );
+        }
+
+        #[test]
         fn inspectable_ols_populates_standard_errors() {
-            use crate::models::inspect::{Explanation, Inspectable};
+            use crate::models::inspect::Explanation;
 
             let ts = make_linear_ts(40);
             let mut model = RegressionForecaster::linear_trend();
@@ -5858,7 +5913,7 @@ mod ols_impl {
             // original-scale weighted covariance, not from the cloned
             // augmented-fit residual. After this fix they must be
             // finite, positive, and length-aligned with coefficients.
-            use crate::models::inspect::{Explanation, Inspectable};
+            use crate::models::inspect::Explanation;
 
             let ts = make_linear_ts(50);
             let mut model = RegressionForecaster::wls_logistic_ridge(
@@ -5908,7 +5963,7 @@ mod ols_impl {
             // SEs returned NaN for every coefficient. The ridge-adjusted
             // sandwich + clamped df_eff must surface finite SEs even on
             // these designs.
-            use crate::models::inspect::{Explanation, Inspectable};
+            use crate::models::inspect::Explanation;
 
             let n = 60;
             let timestamps = make_timestamps(n);

--- a/src/models/tbats/auto.rs
+++ b/src/models/tbats/auto.rs
@@ -386,6 +386,10 @@ impl Forecaster for AutoTBATS {
     fn name(&self) -> &str {
         "AutoTBATS"
     }
+
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
 }
 
 impl Inspectable for AutoTBATS {

--- a/src/models/theta/auto.rs
+++ b/src/models/theta/auto.rs
@@ -362,6 +362,10 @@ impl Forecaster for AutoTheta {
         "AutoTheta"
     }
 
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
+
     fn supports_exog(&self) -> bool {
         true
     }

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -120,6 +120,21 @@ pub trait Forecaster {
         )))
     }
 
+    /// Typed snapshot of the most recent fit (coefficients, in-sample
+    /// fit, model-family metadata). Reads cached state — does not
+    /// re-fit. Returns `Err(FitRequired)` if the model has not been
+    /// fit, or `Err(InvalidParameter)` on models without an
+    /// interpretable structure (baselines, intermittent-demand
+    /// family). Available directly on `Box<dyn Forecaster>` so
+    /// callers no longer have to bound on a second trait or downcast.
+    /// See issue #136.
+    fn explanation(&self) -> Result<crate::models::inspect::Explanation> {
+        Err(ForecastError::InvalidParameter(format!(
+            "{} does not expose an explanation",
+            self.name()
+        )))
+    }
+
     /// Residual component: `training_values - fitted_values`.
     ///
     /// Default impl derives from [`residuals`](Self::residuals) when

--- a/tests/issue_107_inspectable_conformance.rs
+++ b/tests/issue_107_inspectable_conformance.rs
@@ -21,9 +21,7 @@ use anofox_forecast::core::TimeSeries;
 use anofox_forecast::models::arima::AutoARIMA;
 use anofox_forecast::models::exponential::AutoETS;
 use anofox_forecast::models::theta::AutoTheta;
-use anofox_forecast::models::{
-    AutoTBATS, Explanation, Forecaster, Inspectable, MSTLForecaster, MFLES,
-};
+use anofox_forecast::models::{AutoTBATS, Explanation, Forecaster, MSTLForecaster, MFLES};
 
 use chrono::{Duration, TimeZone, Utc};
 
@@ -208,6 +206,8 @@ fn inspectable_is_object_safe() {
     // The trait must be usable behind Box<dyn _> because Explanation
     // is fully owned. This compile-and-call test will fail to link
     // (or panic at fit) if object-safety regresses.
+    use anofox_forecast::models::Inspectable;
+
     let ts = make_seasonal_series(60, 12);
     let mut ets = AutoETS::new();
     ets.fit(&ts).unwrap();


### PR DESCRIPTION
## Summary

Closes #136.

### Added
- **`Forecaster::explanation()`** — new default method on the `Forecaster` trait returning a typed snapshot of the most recent fit. Default returns `Err(InvalidParameter)`. Every model that already implements `Inspectable` overrides it with a one-line delegate: `RegressionForecaster`, `AutoARIMA`, `AutoETS`, `AutoTheta`, `AutoTBATS`, `MFLES`, `MSTLForecaster`.

### Why
Downstream `model_params` extraction (anofox-orchestration #207) was paying the entire per-series fit cost a second time — ~178 s of a 185 s output stage on a 6,319-series / 7-method panel; projected to ~2.9 h on a 367k-series panel. Today the only way to read a fit's coefficients from a `Box<dyn Forecaster>` was either to downcast to `Inspectable` (which the wrapper layer can't easily do) or to call a separate `explanation(train, period)`-style helper that re-fits. The trait method exposes the cached-state path directly.

### Tests
- `boxed_forecaster_exposes_explanation_without_refitting` — through `Box<dyn Forecaster>`, asserts `FitRequired` before fit, then verifies two consecutive `explanation()` calls return identical coefficients (would diverge if it silently re-fit on an iterative backend).
- `boxed_forecaster_explanation_unsupported_default_errs` — `Naive` (no `Inspectable` impl) hits the default `Err(InvalidParameter)` branch.

### Migration
Additive, SemVer-minor. Backward-compatible aside from possible `E0034` ambiguity in tests/code that import `Inspectable` *and* call `model.explanation()` on a concrete model — drop the `Inspectable` import; `Forecaster::explanation` delegates to it.

## Test plan

- [x] `cargo test --lib` — 2873 / 2873 pass (2 new)
- [ ] CI green on the release branch