### PR TITLE
Release v0.12.0-alpha.1: distributional forecasting shell (LaplaceForecaster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.1] - 2026-07-06
+
+### Added
+
+- **`LaplaceForecaster` — distributional forecasting shell (alpha, `distributional` feature).** Streaming, likelihood-weighted mixture over three cheap leaves (EMA, drift, AR(1)); emits a `GaussianMixture` per horizon rather than a point forecast. Inspired by the shell design in [`microprediction/skaters`](https://github.com/microprediction/skaters); the full skaters ensemble (Holt, fractional-differencing, seasonal, Yeo-Johnson, OU mean-reversion, CRPS-tuned terminal leaf) is intentionally deferred. New public surface:
+  - `models::laplace::{Gaussian, GaussianMixture}` — distribution primitives with `mean`/`std`/`quantile`/`logpdf`/`cdf`.
+  - `models::laplace::Leaf` — streaming per-horizon predictor unit.
+  - `models::laplace::LaplaceForecaster` — implements `Forecaster` (point = mixture mean), `Inspectable` (`Explanation::Laplace(_)`), and the new `DistributionalForecaster` trait.
+  - `models::laplace::DistributionalForecaster: Forecaster` — object-safe sibling trait exposing `forecast_dist(&self, horizon) -> Result<Vec<GaussianMixture>>`. Point forecasters remain on `Forecaster` alone; distributional forecasters implement both.
+  - `models::LaplaceExplanation` — payload with `horizon_dists`, `leaf_weights`, `leaf_names`, `fitted_values`, `residuals`.
+- The `Explanation` enum gained a `#[cfg(feature = "distributional")] Laplace(LaplaceExplanation)` variant. The #107 conformance suite covers it.
+
+### Notes
+
+- Alpha surface: the leaf set and mixing scheme may change before the stable `0.12.0`. No downstream code is broken by default builds — the module and enum variant only compile when `distributional` is enabled.
+- Not recommended for price/return series (the empirical wins in the skaters paper are on non-price economic series).
+
 ## [0.11.0] - 2026-06-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"
@@ -21,6 +21,7 @@ postprocess = ["dep:faer", "dep:anofox-regression"]
 forecastability = []
 seasonal-detection = ["dep:fdars-core"]
 serde = ["dep:serde", "dep:serde_json", "dep:bincode"]
+distributional = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.11.0"
+anofox-forecast = "0.12.0-alpha.1"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.11.0",
+  "version": "0.12.0-alpha.1",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.11.0",
+  "version": "0.12.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/inspect.rs
+++ b/src/models/inspect.rs
@@ -49,6 +49,9 @@ pub enum Explanation {
     Tbats(TbatsExplanation),
     /// MSTL (`MSTLForecaster`).
     Mstl(MstlExplanation),
+    /// Laplace distributional shell (`LaplaceForecaster`, `distributional` feature).
+    #[cfg(feature = "distributional")]
+    Laplace(LaplaceExplanation),
 }
 
 /// Interpretable state for regression-backed forecasters.
@@ -202,6 +205,27 @@ pub struct MstlExplanation {
     /// Per-row sum of all seasonal components.
     pub seasonal_component: Vec<f64>,
     /// Per-row STL remainder.
+    pub residuals: Vec<f64>,
+}
+
+/// Interpretable state for the laplace distributional shell.
+///
+/// The shell fits a fixed set of streaming leaves and blends them by
+/// likelihood; this payload captures the terminal state after `fit()`
+/// replays the training series.
+#[cfg(feature = "distributional")]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LaplaceExplanation {
+    /// Predictive gaussian mixture at each horizon `1..=h`.
+    pub horizon_dists: Vec<crate::models::laplace::GaussianMixture>,
+    /// Softmax weight per leaf, aligned with `leaf_names`.
+    pub leaf_weights: Vec<f64>,
+    /// Human-readable leaf identifiers.
+    pub leaf_names: Vec<String>,
+    /// In-sample one-step-ahead mixture means.
+    pub fitted_values: Vec<f64>,
+    /// `training - fitted_values`.
     pub residuals: Vec<f64>,
 }
 

--- a/src/models/laplace/dist.rs
+++ b/src/models/laplace/dist.rs
@@ -1,0 +1,275 @@
+//! Distributional primitives for the laplace forecaster.
+//!
+//! [`Gaussian`] is a single-component normal; [`GaussianMixture`] is a
+//! weighted sum of them. Every horizon of a [`LaplaceForecaster`](super::LaplaceForecaster)
+//! forecast is a `GaussianMixture` — its `.mean()` is the point forecast,
+//! `.quantile()` powers intervals, `.logpdf()` powers the likelihood-based
+//! leaf weighting.
+
+use std::f64::consts::{PI, SQRT_2};
+
+const SQRT_2PI: f64 = 2.506_628_274_631_000_7;
+
+/// Single normal component.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Gaussian {
+    pub mean: f64,
+    pub std: f64,
+}
+
+impl Gaussian {
+    pub const fn new(mean: f64, std: f64) -> Self {
+        Self { mean, std }
+    }
+
+    pub fn variance(&self) -> f64 {
+        self.std * self.std
+    }
+
+    /// Standard-normal PDF evaluated at `z`.
+    fn phi(z: f64) -> f64 {
+        (-0.5 * z * z).exp() / SQRT_2PI
+    }
+
+    /// Standard-normal CDF via `erf`.
+    fn big_phi(z: f64) -> f64 {
+        0.5 * (1.0 + erf(z / SQRT_2))
+    }
+
+    pub fn logpdf(&self, y: f64) -> f64 {
+        let z = (y - self.mean) / self.std;
+        -0.5 * z * z - self.std.ln() - 0.5 * (2.0 * PI).ln()
+    }
+
+    pub fn pdf(&self, y: f64) -> f64 {
+        Self::phi((y - self.mean) / self.std) / self.std
+    }
+
+    pub fn cdf(&self, y: f64) -> f64 {
+        Self::big_phi((y - self.mean) / self.std)
+    }
+
+    /// Inverse CDF (quantile). `p` must be in `(0, 1)`.
+    pub fn quantile(&self, p: f64) -> f64 {
+        self.mean + self.std * SQRT_2 * inv_erf(2.0 * p - 1.0)
+    }
+}
+
+/// Weighted mixture of gaussians. Weights are normalised on construction.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GaussianMixture {
+    /// `(weight, component)` pairs. Weights sum to 1.
+    pub components: Vec<(f64, Gaussian)>,
+}
+
+impl GaussianMixture {
+    /// Build from `(weight, component)` pairs. Non-finite or non-positive
+    /// weights are dropped; the surviving weights are re-normalised. Returns
+    /// an empty mixture if nothing survives.
+    pub fn new(pairs: impl IntoIterator<Item = (f64, Gaussian)>) -> Self {
+        let mut kept: Vec<(f64, Gaussian)> = pairs
+            .into_iter()
+            .filter(|(w, _)| w.is_finite() && *w > 0.0)
+            .collect();
+        let sum: f64 = kept.iter().map(|(w, _)| *w).sum();
+        if sum > 0.0 {
+            for (w, _) in &mut kept {
+                *w /= sum;
+            }
+        }
+        Self { components: kept }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Mixture mean: `Σ w_i · μ_i`.
+    pub fn mean(&self) -> f64 {
+        self.components.iter().map(|(w, g)| w * g.mean).sum()
+    }
+
+    /// Mixture variance: `Σ w_i (σ_i² + (μ_i − μ_mix)²)`.
+    pub fn variance(&self) -> f64 {
+        let mu = self.mean();
+        self.components
+            .iter()
+            .map(|(w, g)| w * (g.variance() + (g.mean - mu).powi(2)))
+            .sum()
+    }
+
+    pub fn std(&self) -> f64 {
+        self.variance().sqrt()
+    }
+
+    pub fn pdf(&self, y: f64) -> f64 {
+        self.components.iter().map(|(w, g)| w * g.pdf(y)).sum()
+    }
+
+    /// log-sum-exp of component log-densities.
+    pub fn logpdf(&self, y: f64) -> f64 {
+        if self.components.is_empty() {
+            return f64::NEG_INFINITY;
+        }
+        let logs: Vec<f64> = self
+            .components
+            .iter()
+            .map(|(w, g)| w.ln() + g.logpdf(y))
+            .collect();
+        let m = logs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        if !m.is_finite() {
+            return m;
+        }
+        m + logs.iter().map(|l| (l - m).exp()).sum::<f64>().ln()
+    }
+
+    pub fn cdf(&self, y: f64) -> f64 {
+        self.components.iter().map(|(w, g)| w * g.cdf(y)).sum()
+    }
+
+    /// Quantile via bisection over the mixture CDF.
+    pub fn quantile(&self, p: f64) -> f64 {
+        if self.components.is_empty() {
+            return f64::NAN;
+        }
+        if self.components.len() == 1 {
+            return self.components[0].1.quantile(p);
+        }
+        // Bracket using the widest per-component range at 1e-9 tails.
+        let lo = self
+            .components
+            .iter()
+            .map(|(_, g)| g.quantile(1e-9))
+            .fold(f64::INFINITY, f64::min);
+        let hi = self
+            .components
+            .iter()
+            .map(|(_, g)| g.quantile(1.0 - 1e-9))
+            .fold(f64::NEG_INFINITY, f64::max);
+        bisect(lo, hi, |x| self.cdf(x) - p, 1e-10, 80)
+    }
+}
+
+fn bisect(mut lo: f64, mut hi: f64, f: impl Fn(f64) -> f64, tol: f64, max_iter: usize) -> f64 {
+    for _ in 0..max_iter {
+        let mid = 0.5 * (lo + hi);
+        let fm = f(mid);
+        if fm.abs() < tol || (hi - lo) < tol {
+            return mid;
+        }
+        if fm < 0.0 {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+/// Abramowitz & Stegun 7.1.26 rational approximation to `erf`.
+/// Absolute error ≤ 1.5e-7 — good enough for a shell (Gaussian tails).
+fn erf(x: f64) -> f64 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * x);
+    let poly = t
+        * (0.254829592
+            + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+    sign * (1.0 - poly * (-x * x).exp())
+}
+
+/// Winitzki approximation to `erf⁻¹`; ~1e-4 accurate, refined by one Newton step.
+fn inv_erf(x: f64) -> f64 {
+    let clipped = x.clamp(-0.999_999_999, 0.999_999_999);
+    let a = 0.147;
+    let ln = (1.0 - clipped * clipped).ln();
+    let inner = 2.0 / (PI * a) + 0.5 * ln;
+    let mut y = clipped.signum() * (inner.mul_add(inner, -ln / a).sqrt() - inner).sqrt();
+    // One Newton step against erf(y) − x = 0; derivative = 2/√π · e^{-y²}.
+    let f = erf(y) - clipped;
+    let df = 2.0 / PI.sqrt() * (-y * y).exp();
+    if df.is_finite() && df > 0.0 {
+        y -= f / df;
+    }
+    y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_normal_pdf_cdf_quantile() {
+        let g = Gaussian::new(0.0, 1.0);
+        assert!((g.pdf(0.0) - 1.0 / SQRT_2PI).abs() < 1e-12);
+        assert!((g.cdf(0.0) - 0.5).abs() < 1e-6);
+        assert!((g.quantile(0.5) - 0.0).abs() < 1e-6);
+        assert!((g.quantile(0.975) - 1.959_963_984_540_054).abs() < 1e-3);
+    }
+
+    #[test]
+    fn logpdf_matches_pdf_ln() {
+        let g = Gaussian::new(2.5, 0.7);
+        for &y in &[-1.0, 0.0, 2.5, 4.0] {
+            assert!((g.logpdf(y) - g.pdf(y).ln()).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn mixture_mean_is_weighted_sum() {
+        let m = GaussianMixture::new([
+            (0.3, Gaussian::new(1.0, 0.5)),
+            (0.7, Gaussian::new(3.0, 0.5)),
+        ]);
+        let expected = 0.3 * 1.0 + 0.7 * 3.0;
+        assert!((m.mean() - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mixture_variance_includes_between_component_spread() {
+        let m = GaussianMixture::new([
+            (0.5, Gaussian::new(0.0, 1.0)),
+            (0.5, Gaussian::new(4.0, 1.0)),
+        ]);
+        // Between = 0.5·(0-2)² + 0.5·(4-2)² = 4; within = 1 → total 5.
+        assert!((m.variance() - 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mixture_weights_normalise() {
+        let m = GaussianMixture::new([
+            (2.0, Gaussian::new(0.0, 1.0)),
+            (3.0, Gaussian::new(0.0, 1.0)),
+        ]);
+        let sum: f64 = m.components.iter().map(|(w, _)| w).sum();
+        assert!((sum - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mixture_quantile_monotone() {
+        let m = GaussianMixture::new([
+            (0.4, Gaussian::new(-2.0, 0.6)),
+            (0.6, Gaussian::new(1.5, 1.2)),
+        ]);
+        let ps = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95];
+        let mut prev = f64::NEG_INFINITY;
+        for &p in &ps {
+            let q = m.quantile(p);
+            assert!(q > prev, "quantile not monotone at p={p}: {q} <= {prev}");
+            prev = q;
+        }
+    }
+
+    #[test]
+    fn empty_mixture_reports_neg_inf_logpdf() {
+        let m = GaussianMixture::new(std::iter::empty::<(f64, Gaussian)>());
+        assert!(m.is_empty());
+        assert_eq!(m.logpdf(0.0), f64::NEG_INFINITY);
+    }
+}

--- a/src/models/laplace/ensemble.rs
+++ b/src/models/laplace/ensemble.rs
@@ -1,0 +1,97 @@
+//! Likelihood-weighted mixture over leaves.
+//!
+//! Each leaf keeps a running cumulative one-step log-likelihood. Weights
+//! are computed on demand as `softmax(cum_log_lik)`. `blend_horizon`
+//! folds per-leaf horizon predictions into a single [`GaussianMixture`]
+//! per step.
+
+use super::dist::{Gaussian, GaussianMixture};
+
+/// Turn cumulative log-likelihoods into normalised softmax weights.
+///
+/// Empty input returns empty. Non-finite entries (`NaN` / `-Inf`) are
+/// treated as `f64::NEG_INFINITY` for numerical safety.
+pub fn softmax(log_liks: &[f64]) -> Vec<f64> {
+    if log_liks.is_empty() {
+        return Vec::new();
+    }
+    let max = log_liks
+        .iter()
+        .copied()
+        .filter(|l| l.is_finite())
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !max.is_finite() {
+        // All leaves useless — fall back to uniform.
+        let n = log_liks.len() as f64;
+        return vec![1.0 / n; log_liks.len()];
+    }
+    let exps: Vec<f64> = log_liks
+        .iter()
+        .map(|&l| if l.is_finite() { (l - max).exp() } else { 0.0 })
+        .collect();
+    let sum: f64 = exps.iter().sum();
+    if sum <= 0.0 {
+        let n = log_liks.len() as f64;
+        return vec![1.0 / n; log_liks.len()];
+    }
+    exps.iter().map(|e| e / sum).collect()
+}
+
+/// For a fixed horizon `h`, produce the mixture over `weights.len()` leaves.
+///
+/// `per_leaf_horizons[i]` is leaf `i`'s vector of per-horizon gaussians
+/// (length `≥ h`). Returns an empty mixture if inputs are inconsistent.
+pub fn blend_horizon(
+    weights: &[f64],
+    per_leaf_horizons: &[Vec<Gaussian>],
+    h_index: usize,
+) -> GaussianMixture {
+    if weights.len() != per_leaf_horizons.len() {
+        return GaussianMixture::default();
+    }
+    let pairs = weights
+        .iter()
+        .zip(per_leaf_horizons.iter())
+        .filter_map(|(w, horizons)| horizons.get(h_index).map(|g| (*w, *g)));
+    GaussianMixture::new(pairs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn softmax_uniform_when_all_equal() {
+        let w = softmax(&[-1.0, -1.0, -1.0]);
+        for wi in w {
+            assert!((wi - 1.0 / 3.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn softmax_normalised_and_ordering_preserved() {
+        let w = softmax(&[-10.0, -1.0, 0.0]);
+        assert!((w.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+        assert!(w[0] < w[1] && w[1] < w[2]);
+    }
+
+    #[test]
+    fn softmax_all_nan_falls_back_to_uniform() {
+        let w = softmax(&[f64::NAN, f64::NAN]);
+        assert!((w[0] - 0.5).abs() < 1e-12);
+        assert!((w[1] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn blend_horizon_matches_expected_mixture() {
+        let leaves = vec![
+            vec![Gaussian::new(0.0, 1.0), Gaussian::new(0.0, 2.0)],
+            vec![Gaussian::new(2.0, 1.0), Gaussian::new(2.0, 2.0)],
+        ];
+        let weights = vec![0.25, 0.75];
+        let m = blend_horizon(&weights, &leaves, 0);
+        assert_eq!(m.components.len(), 2);
+        // Point forecast at h=1 = 0.25·0 + 0.75·2 = 1.5.
+        assert!((m.mean() - 1.5).abs() < 1e-12);
+    }
+}

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -1,0 +1,334 @@
+//! `LaplaceForecaster` — online distributional shell over EMA / drift / AR(1).
+//!
+//! Alpha surface (behind the `distributional` feature). Inspired by
+//! [`microprediction/skaters`](https://github.com/microprediction/skaters):
+//! streaming leaves, likelihood-weighted mixture, per-horizon
+//! [`GaussianMixture`](super::dist::GaussianMixture) output. Only the shell
+//! and three cheap leaves are implemented — no CRPS terminal, no
+//! seasonal / OU / fractional-differencing / Yeo-Johnson leaves.
+
+use crate::core::{Forecast, TimeSeries};
+use crate::error::{ForecastError, Result};
+use crate::models::inspect::{Explanation, Inspectable, LaplaceExplanation};
+use crate::models::traits::{validate_series_complete, Forecaster};
+
+use super::dist::GaussianMixture;
+use super::ensemble::{blend_horizon, softmax};
+use super::leaf::Leaf;
+use super::leaves::{Ar1Leaf, DriftLeaf, EmaLeaf};
+use super::DistributionalForecaster;
+
+/// Distributional forecaster returning a `GaussianMixture` per horizon.
+///
+/// Wraps three streaming leaves (EMA, drift, AR(1)) and mixes them by
+/// cumulative one-step log-likelihood.
+pub struct LaplaceForecaster {
+    ema_alpha: f64,
+    drift_alpha: f64,
+    ar_alpha_mean: f64,
+
+    leaves: Vec<Box<dyn Leaf + Send>>,
+    cum_log_liks: Vec<f64>,
+    n_obs: usize,
+
+    fitted_values: Vec<f64>,
+    residuals: Vec<f64>,
+    training_values: Vec<f64>,
+}
+
+impl LaplaceForecaster {
+    /// Default configuration: EMA α=0.2, drift α=0.1, AR(1) mean α=0.1.
+    pub fn new() -> Self {
+        Self::with_alphas(0.2, 0.1, 0.1)
+    }
+
+    pub fn with_alphas(ema_alpha: f64, drift_alpha: f64, ar_alpha_mean: f64) -> Self {
+        Self {
+            ema_alpha,
+            drift_alpha,
+            ar_alpha_mean,
+            leaves: Vec::new(),
+            cum_log_liks: Vec::new(),
+            n_obs: 0,
+            fitted_values: Vec::new(),
+            residuals: Vec::new(),
+            training_values: Vec::new(),
+        }
+    }
+
+    fn init_leaves(&mut self) {
+        self.leaves = vec![
+            Box::new(EmaLeaf::new(self.ema_alpha)),
+            Box::new(DriftLeaf::new(self.drift_alpha)),
+            Box::new(Ar1Leaf::new(self.ar_alpha_mean)),
+        ];
+        self.cum_log_liks = vec![0.0; self.leaves.len()];
+    }
+
+    fn weights(&self) -> Vec<f64> {
+        softmax(&self.cum_log_liks)
+    }
+
+    fn per_leaf_horizons(&self, horizon: usize) -> Vec<Vec<super::dist::Gaussian>> {
+        self.leaves.iter().map(|l| l.predict(horizon)).collect()
+    }
+}
+
+impl Default for LaplaceForecaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Forecaster for LaplaceForecaster {
+    fn fit(&mut self, series: &TimeSeries) -> Result<()> {
+        validate_series_complete(series)?;
+        let values = series.primary_values();
+        if values.is_empty() {
+            return Err(ForecastError::InvalidParameter(
+                "LaplaceForecaster requires at least one observation".into(),
+            ));
+        }
+
+        self.init_leaves();
+        self.training_values = values.to_vec();
+        self.fitted_values = Vec::with_capacity(values.len());
+        self.residuals = Vec::with_capacity(values.len());
+        self.n_obs = 0;
+
+        for &y in values {
+            // 1-step predictions from each leaf, before observing y.
+            let per_leaf: Vec<super::dist::Gaussian> =
+                self.leaves.iter().map(|l| l.predict(1)[0]).collect();
+            let weights = self.weights();
+
+            let mixture =
+                GaussianMixture::new(weights.iter().zip(per_leaf.iter()).map(|(w, g)| (*w, *g)));
+            let fitted = if mixture.is_empty() {
+                y
+            } else {
+                mixture.mean()
+            };
+            self.fitted_values.push(fitted);
+            self.residuals.push(y - fitted);
+
+            // Score each leaf on this y, then absorb.
+            for (i, leaf) in self.leaves.iter_mut().enumerate() {
+                let g = per_leaf[i];
+                let lp = g.logpdf(y);
+                if lp.is_finite() {
+                    self.cum_log_liks[i] += lp;
+                }
+                leaf.observe(y);
+            }
+            self.n_obs += 1;
+        }
+        Ok(())
+    }
+
+    fn predict(&self, horizon: usize) -> Result<Forecast> {
+        if self.leaves.is_empty() {
+            return Err(ForecastError::FitRequired {
+                model: Some("LaplaceForecaster".into()),
+            });
+        }
+        if horizon == 0 {
+            return Ok(Forecast::from_values(Vec::new()));
+        }
+        let mixtures = self.forecast_dist(horizon)?;
+        let points: Vec<f64> = mixtures.iter().map(|m| m.mean()).collect();
+        Ok(Forecast::from_values(points))
+    }
+
+    fn predict_with_intervals(&self, horizon: usize, level: f64) -> Result<Forecast> {
+        if self.leaves.is_empty() {
+            return Err(ForecastError::FitRequired {
+                model: Some("LaplaceForecaster".into()),
+            });
+        }
+        if !(0.0..1.0).contains(&level) {
+            return Err(ForecastError::InvalidParameter(format!(
+                "confidence level must be in [0, 1), got {level}"
+            )));
+        }
+        let mixtures = self.forecast_dist(horizon)?;
+        let alpha = 1.0 - level;
+        let lo_p = alpha / 2.0;
+        let hi_p = 1.0 - alpha / 2.0;
+        let points: Vec<f64> = mixtures.iter().map(|m| m.mean()).collect();
+        let lower: Vec<f64> = mixtures.iter().map(|m| m.quantile(lo_p)).collect();
+        let upper: Vec<f64> = mixtures.iter().map(|m| m.quantile(hi_p)).collect();
+        Ok(Forecast::from_values_with_intervals(points, lower, upper))
+    }
+
+    fn fitted_values(&self) -> Option<&[f64]> {
+        if self.fitted_values.is_empty() {
+            None
+        } else {
+            Some(&self.fitted_values)
+        }
+    }
+
+    fn residuals(&self) -> Option<&[f64]> {
+        if self.residuals.is_empty() {
+            None
+        } else {
+            Some(&self.residuals)
+        }
+    }
+
+    fn training_values(&self) -> Result<&[f64]> {
+        if self.training_values.is_empty() {
+            Err(ForecastError::FitRequired {
+                model: Some("LaplaceForecaster".into()),
+            })
+        } else {
+            Ok(&self.training_values)
+        }
+    }
+
+    fn name(&self) -> &str {
+        "LaplaceForecaster"
+    }
+
+    fn explanation(&self) -> Result<Explanation> {
+        <Self as Inspectable>::explanation(self)
+    }
+}
+
+impl Inspectable for LaplaceForecaster {
+    fn explanation(&self) -> Result<Explanation> {
+        if self.leaves.is_empty() {
+            return Err(ForecastError::FitRequired {
+                model: Some("LaplaceForecaster".into()),
+            });
+        }
+        let horizon = 8;
+        let mixtures = self.forecast_dist(horizon)?;
+        let weights = self.weights();
+        let names = self.leaves.iter().map(|l| l.name().to_string()).collect();
+        Ok(Explanation::Laplace(LaplaceExplanation {
+            horizon_dists: mixtures,
+            leaf_weights: weights,
+            leaf_names: names,
+            fitted_values: self.fitted_values.clone(),
+            residuals: self.residuals.clone(),
+        }))
+    }
+}
+
+impl DistributionalForecaster for LaplaceForecaster {
+    fn forecast_dist(&self, horizon: usize) -> Result<Vec<GaussianMixture>> {
+        if self.leaves.is_empty() {
+            return Err(ForecastError::FitRequired {
+                model: Some("LaplaceForecaster".into()),
+            });
+        }
+        if horizon == 0 {
+            return Ok(Vec::new());
+        }
+        let weights = self.weights();
+        let per_leaf = self.per_leaf_horizons(horizon);
+        Ok((0..horizon)
+            .map(|h| blend_horizon(&weights, &per_leaf, h))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::TimeSeries;
+    use chrono::{Duration, TimeZone, Utc};
+
+    fn ts_ar1(n: usize, phi: f64) -> TimeSeries {
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let mut vals = Vec::with_capacity(n);
+        let mut y = 0.0;
+        for i in 0..n {
+            let eps = ((i as f64 * 12.9898).sin() * 43758.5453).fract() - 0.5;
+            y = phi * y + eps;
+            vals.push(y);
+        }
+        let stamps: Vec<_> = (0..n).map(|i| base + Duration::hours(i as i64)).collect();
+        TimeSeries::univariate(stamps, vals).unwrap()
+    }
+
+    #[test]
+    fn fit_and_forecast_dist_returns_mixture_per_horizon() {
+        let ts = ts_ar1(200, 0.6);
+        let mut f = LaplaceForecaster::new();
+        f.fit(&ts).unwrap();
+        let dists = f.forecast_dist(5).unwrap();
+        assert_eq!(dists.len(), 5);
+        for d in &dists {
+            assert_eq!(d.components.len(), 3);
+            let ws: f64 = d.components.iter().map(|(w, _)| w).sum();
+            assert!((ws - 1.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn predict_matches_mixture_means() {
+        let ts = ts_ar1(150, 0.5);
+        let mut f = LaplaceForecaster::new();
+        f.fit(&ts).unwrap();
+        let dists = f.forecast_dist(3).unwrap();
+        let fc = f.predict(3).unwrap();
+        let means: Vec<f64> = dists.iter().map(|m| m.mean()).collect();
+        assert_eq!(fc.primary(), means.as_slice());
+    }
+
+    #[test]
+    fn predict_before_fit_errors() {
+        let f = LaplaceForecaster::new();
+        assert!(matches!(
+            f.predict(1),
+            Err(ForecastError::FitRequired { .. })
+        ));
+        assert!(matches!(
+            f.forecast_dist(1),
+            Err(ForecastError::FitRequired { .. })
+        ));
+    }
+
+    #[test]
+    fn intervals_are_ordered() {
+        let ts = ts_ar1(120, 0.4);
+        let mut f = LaplaceForecaster::new();
+        f.fit(&ts).unwrap();
+        let fc = f.predict_with_intervals(3, 0.90).unwrap();
+        let lower = fc.lower_series(0).unwrap();
+        let upper = fc.upper_series(0).unwrap();
+        let point = fc.primary();
+        for i in 0..3 {
+            assert!(lower[i] <= point[i] && point[i] <= upper[i]);
+        }
+    }
+
+    #[test]
+    fn explanation_after_fit_matches_leaf_names() {
+        let ts = ts_ar1(80, 0.5);
+        let mut f = LaplaceForecaster::new();
+        f.fit(&ts).unwrap();
+        match Inspectable::explanation(&f).unwrap() {
+            Explanation::Laplace(e) => {
+                assert_eq!(e.leaf_names, vec!["ema", "drift", "ar1"]);
+                assert_eq!(e.leaf_weights.len(), 3);
+                assert!(!e.fitted_values.is_empty());
+                assert_eq!(e.fitted_values.len(), e.residuals.len());
+                assert_eq!(e.horizon_dists.len(), 8);
+            }
+            other => panic!("expected Explanation::Laplace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explanation_before_fit_errors() {
+        let f = LaplaceForecaster::new();
+        assert!(matches!(
+            Inspectable::explanation(&f),
+            Err(ForecastError::FitRequired { .. })
+        ));
+    }
+}

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -3,7 +3,7 @@
 //! Alpha surface (behind the `distributional` feature). Inspired by
 //! [`microprediction/skaters`](https://github.com/microprediction/skaters):
 //! streaming leaves, likelihood-weighted mixture, per-horizon
-//! [`GaussianMixture`](super::dist::GaussianMixture) output. Only the shell
+//! [`GaussianMixture`] output. Only the shell
 //! and three cheap leaves are implemented — no CRPS terminal, no
 //! seasonal / OU / fractional-differencing / Yeo-Johnson leaves.
 

--- a/src/models/laplace/leaf.rs
+++ b/src/models/laplace/leaf.rs
@@ -1,0 +1,22 @@
+//! `Leaf` trait — the online predictor unit that laplace ensembles over.
+//!
+//! A leaf is a small streaming model that consumes observations one at a
+//! time and emits per-horizon `Gaussian` predictions. The ensemble in
+//! [`ensemble`](super::ensemble) tracks each leaf's cumulative log-likelihood
+//! and turns those into softmax weights.
+
+use super::dist::Gaussian;
+
+/// Streaming per-horizon predictor.
+pub trait Leaf {
+    fn name(&self) -> &'static str;
+
+    /// Return the *current* h-step-ahead predictive distributions, one per
+    /// horizon in `1..=horizon`. Called *before* the next observation is
+    /// absorbed, so the returned distributions are honest one-step (and
+    /// h-step) forecasts.
+    fn predict(&self, horizon: usize) -> Vec<Gaussian>;
+
+    /// Absorb one observation and update internal state.
+    fn observe(&mut self, y: f64);
+}

--- a/src/models/laplace/leaves/ar.rs
+++ b/src/models/laplace/leaves/ar.rs
@@ -1,0 +1,100 @@
+//! AR(1) leaf with online mean & OLS-updated φ.
+//!
+//! Fits `y_t − μ = φ · (y_{t−1} − μ) + ε`. Point forecast at horizon `h`:
+//! `μ + φ^h · (y_t − μ)`. Predictive std at horizon `h`:
+//! `σ · √(Σ_{i=0..h} φ^{2i})`.
+
+use crate::models::laplace::dist::Gaussian;
+use crate::models::laplace::leaf::Leaf;
+
+pub struct Ar1Leaf {
+    alpha_mean: f64,
+    mean: Option<f64>,
+    last: Option<f64>,
+    // Sufficient stats on centred products for online OLS on φ.
+    s_xx: f64, // Σ (y_{t−1} − μ)²
+    s_xy: f64, // Σ (y_{t−1} − μ)(y_t − μ)
+    phi: f64,
+    n: usize,
+    ss: f64,
+    mean_resid: f64,
+}
+
+impl Ar1Leaf {
+    pub fn new(alpha_mean: f64) -> Self {
+        Self {
+            alpha_mean: alpha_mean.clamp(1e-3, 1.0 - 1e-3),
+            mean: None,
+            last: None,
+            s_xx: 0.0,
+            s_xy: 0.0,
+            phi: 0.0,
+            n: 0,
+            ss: 0.0,
+            mean_resid: 0.0,
+        }
+    }
+
+    fn sigma(&self) -> f64 {
+        if self.n < 2 {
+            return 1.0;
+        }
+        (self.ss / (self.n as f64 - 1.0)).sqrt().max(1e-9)
+    }
+}
+
+impl Leaf for Ar1Leaf {
+    fn name(&self) -> &'static str {
+        "ar1"
+    }
+
+    fn predict(&self, horizon: usize) -> Vec<Gaussian> {
+        let mu = self.mean.unwrap_or(0.0);
+        let last = self.last.unwrap_or(mu);
+        let sigma = self.sigma();
+        let phi = self.phi.clamp(-0.999, 0.999);
+        (1..=horizon)
+            .map(|h| {
+                let phi_h = phi.powi(h as i32);
+                let mean = mu + phi_h * (last - mu);
+                // Var = σ² · Σ_{i=0..h−1} φ^{2i}
+                let phi2 = phi * phi;
+                let var_scale = if (1.0 - phi2).abs() < 1e-12 {
+                    h as f64
+                } else {
+                    (1.0 - phi2.powi(h as i32)) / (1.0 - phi2)
+                };
+                Gaussian::new(mean, sigma * var_scale.sqrt())
+            })
+            .collect()
+    }
+
+    fn observe(&mut self, y: f64) {
+        let mu_before = self.mean.unwrap_or(y);
+        let last = self.last.unwrap_or(mu_before);
+
+        let predicted = mu_before + self.phi * (last - mu_before);
+        let resid = y - predicted;
+        self.n += 1;
+        let delta = resid - self.mean_resid;
+        self.mean_resid += delta / self.n as f64;
+        self.ss += delta * (resid - self.mean_resid);
+
+        // Sufficient stats update — use the pre-update mean so both sides are
+        // centred with the same μ (small bias vs. true centred OLS but stable
+        // in a streaming setting).
+        let x = last - mu_before;
+        let z = y - mu_before;
+        self.s_xx += x * x;
+        self.s_xy += x * z;
+        if self.s_xx > 1e-12 {
+            self.phi = (self.s_xy / self.s_xx).clamp(-0.999, 0.999);
+        }
+
+        self.mean = Some(match self.mean {
+            Some(m) => self.alpha_mean * y + (1.0 - self.alpha_mean) * m,
+            None => y,
+        });
+        self.last = Some(y);
+    }
+}

--- a/src/models/laplace/leaves/drift.rs
+++ b/src/models/laplace/leaves/drift.rs
@@ -1,0 +1,71 @@
+//! Drift leaf — level plus a smoothed step size.
+//!
+//! Point forecast at horizon `h`: `level + h · drift`, where `drift` is an
+//! EMA of first differences. Predictive std grows as `σ · √h`.
+
+use crate::models::laplace::dist::Gaussian;
+use crate::models::laplace::leaf::Leaf;
+
+pub struct DriftLeaf {
+    alpha: f64,
+    level: Option<f64>,
+    drift: f64,
+    prev: Option<f64>,
+    n: usize,
+    ss: f64,
+    mean_resid: f64,
+}
+
+impl DriftLeaf {
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            alpha: alpha.clamp(1e-3, 1.0 - 1e-3),
+            level: None,
+            drift: 0.0,
+            prev: None,
+            n: 0,
+            ss: 0.0,
+            mean_resid: 0.0,
+        }
+    }
+
+    fn sigma(&self) -> f64 {
+        if self.n < 2 {
+            return 1.0;
+        }
+        (self.ss / (self.n as f64 - 1.0)).sqrt().max(1e-9)
+    }
+}
+
+impl Leaf for DriftLeaf {
+    fn name(&self) -> &'static str {
+        "drift"
+    }
+
+    fn predict(&self, horizon: usize) -> Vec<Gaussian> {
+        let level = self.level.unwrap_or(0.0);
+        let base = self.sigma();
+        (1..=horizon)
+            .map(|h| Gaussian::new(level + h as f64 * self.drift, base * (h as f64).sqrt()))
+            .collect()
+    }
+
+    fn observe(&mut self, y: f64) {
+        let predicted = self.level.map(|l| l + self.drift).unwrap_or(y);
+        let resid = y - predicted;
+        self.n += 1;
+        let delta = resid - self.mean_resid;
+        self.mean_resid += delta / self.n as f64;
+        self.ss += delta * (resid - self.mean_resid);
+
+        if let Some(prev) = self.prev {
+            let step = y - prev;
+            self.drift = self.alpha * step + (1.0 - self.alpha) * self.drift;
+        }
+        self.level = Some(match self.level {
+            Some(l) => self.alpha * y + (1.0 - self.alpha) * l,
+            None => y,
+        });
+        self.prev = Some(y);
+    }
+}

--- a/src/models/laplace/leaves/ema.rs
+++ b/src/models/laplace/leaves/ema.rs
@@ -1,0 +1,63 @@
+//! Exponentially-weighted level leaf.
+//!
+//! Point forecast at any horizon = current EMA of `y`. Predictive std
+//! grows with horizon as `σ · √h` (random-walk on the level).
+
+use crate::models::laplace::dist::Gaussian;
+use crate::models::laplace::leaf::Leaf;
+
+pub struct EmaLeaf {
+    alpha: f64,
+    level: Option<f64>,
+    n: usize,
+    ss: f64,
+    mean_resid: f64,
+}
+
+impl EmaLeaf {
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            alpha: alpha.clamp(1e-3, 1.0 - 1e-3),
+            level: None,
+            n: 0,
+            ss: 0.0,
+            mean_resid: 0.0,
+        }
+    }
+
+    fn sigma(&self) -> f64 {
+        if self.n < 2 {
+            return 1.0;
+        }
+        let var = self.ss / (self.n as f64 - 1.0);
+        var.sqrt().max(1e-9)
+    }
+}
+
+impl Leaf for EmaLeaf {
+    fn name(&self) -> &'static str {
+        "ema"
+    }
+
+    fn predict(&self, horizon: usize) -> Vec<Gaussian> {
+        let level = self.level.unwrap_or(0.0);
+        let base = self.sigma();
+        (1..=horizon)
+            .map(|h| Gaussian::new(level, base * (h as f64).sqrt()))
+            .collect()
+    }
+
+    fn observe(&mut self, y: f64) {
+        let predicted = self.level.unwrap_or(y);
+        let resid = y - predicted;
+        // Welford update on residuals.
+        self.n += 1;
+        let delta = resid - self.mean_resid;
+        self.mean_resid += delta / self.n as f64;
+        self.ss += delta * (resid - self.mean_resid);
+        self.level = Some(match self.level {
+            Some(l) => self.alpha * y + (1.0 - self.alpha) * l,
+            None => y,
+        });
+    }
+}

--- a/src/models/laplace/leaves/mod.rs
+++ b/src/models/laplace/leaves/mod.rs
@@ -1,0 +1,9 @@
+//! Concrete `Leaf` implementations composed by [`LaplaceForecaster`](super::LaplaceForecaster).
+
+mod ar;
+mod drift;
+mod ema;
+
+pub use ar::Ar1Leaf;
+pub use drift::DriftLeaf;
+pub use ema::EmaLeaf;

--- a/src/models/laplace/mod.rs
+++ b/src/models/laplace/mod.rs
@@ -1,0 +1,48 @@
+//! Distributional forecasting shell (alpha, `distributional` feature).
+//!
+//! Inspired by [`microprediction/skaters`](https://github.com/microprediction/skaters):
+//! streaming leaves, per-observation likelihood-weighted mixture, per-horizon
+//! [`GaussianMixture`] output. Only the shell and three cheap leaves
+//! (EMA, drift, AR(1)) are wired up here — the full skaters ensemble
+//! (seasonal, OU, fractional-differencing, Yeo-Johnson) is deferred.
+//!
+//! # Example
+//! ```ignore
+//! use anofox_forecast::models::laplace::{LaplaceForecaster, DistributionalForecaster};
+//! use anofox_forecast::models::Forecaster;
+//!
+//! let mut f = LaplaceForecaster::new();
+//! f.fit(&ts)?;
+//! let dists = f.forecast_dist(5)?;                  // Vec<GaussianMixture>
+//! let intervals = f.predict_with_intervals(5, 0.9)?; // point + P05/P95
+//! ```
+//!
+//! The distributional surface is exposed via the [`DistributionalForecaster`]
+//! trait; the point-forecast surface via the existing
+//! [`Forecaster`](crate::models::Forecaster) trait. The mixture parameters
+//! are also reachable via [`Explanation::Laplace`](crate::models::Explanation).
+
+pub mod dist;
+pub mod ensemble;
+pub mod forecaster;
+pub mod leaf;
+pub mod leaves;
+
+pub use dist::{Gaussian, GaussianMixture};
+pub use forecaster::LaplaceForecaster;
+pub use leaf::Leaf;
+
+use crate::error::Result;
+
+/// Trait for models that emit per-horizon predictive densities.
+///
+/// Sibling to [`Forecaster`](crate::models::Forecaster) — implementers must
+/// also implement `Forecaster` (point forecast = mixture mean). Object-safe:
+/// `Box<dyn DistributionalForecaster>` works.
+pub trait DistributionalForecaster: crate::models::Forecaster {
+    /// Predictive `GaussianMixture` for each step in `1..=horizon`.
+    ///
+    /// # Errors
+    /// - `FitRequired` if the model has not been fit.
+    fn forecast_dist(&self, horizon: usize) -> Result<Vec<GaussianMixture>>;
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -14,6 +14,8 @@ pub mod garch;
 pub mod intermittent;
 pub mod kalman;
 pub mod kalman_forecaster;
+#[cfg(feature = "distributional")]
+pub mod laplace;
 pub mod mfles;
 pub mod mstl_forecaster;
 pub mod regression;
@@ -23,11 +25,15 @@ pub mod var;
 pub mod var_forecaster;
 
 pub use garch::GARCH;
+#[cfg(feature = "distributional")]
+pub use inspect::LaplaceExplanation;
 pub use inspect::{
     ArimaExplanation, EtsExplanation, Explanation, Inspectable, MflesExplanation, MstlExplanation,
     RegressionExplanation, TbatsExplanation, ThetaExplanation,
 };
 pub use kalman_forecaster::KalmanForecaster;
+#[cfg(feature = "distributional")]
+pub use laplace::{DistributionalForecaster, Gaussian, GaussianMixture, LaplaceForecaster};
 pub use mfles::MFLES;
 pub use mstl_forecaster::{MSTLForecaster, SeasonalForecastMethod, TrendForecastMethod};
 pub use tbats::{AutoTBATS, TBATS};

--- a/tests/issue_107_inspectable_conformance.rs
+++ b/tests/issue_107_inspectable_conformance.rs
@@ -84,6 +84,20 @@ fn assert_finite_scalars(label: &str, e: &Explanation) {
             );
             assert!(m.iterations > 0, "{label}: iterations must be > 0");
         }
+        #[cfg(feature = "distributional")]
+        Explanation::Laplace(l) => {
+            assert!(!l.leaf_names.is_empty(), "{label}: leaf_names empty");
+            assert_eq!(
+                l.leaf_names.len(),
+                l.leaf_weights.len(),
+                "{label}: leaf_names/weights length mismatch"
+            );
+            let ws: f64 = l.leaf_weights.iter().sum();
+            assert!(
+                (ws - 1.0).abs() < 1e-9,
+                "{label}: leaf_weights don't sum to 1"
+            );
+        }
     }
 }
 
@@ -96,6 +110,8 @@ fn assert_spine(label: &str, e: &Explanation) {
         Explanation::Theta(x) => (&x.fitted_values, &x.residuals),
         Explanation::Tbats(x) => (&x.fitted_values, &x.residuals),
         Explanation::Mstl(x) => (&x.fitted_values, &x.residuals),
+        #[cfg(feature = "distributional")]
+        Explanation::Laplace(x) => (&x.fitted_values, &x.residuals),
     };
     assert!(!fitted.is_empty(), "{label}: fitted_values empty");
     assert_eq!(
@@ -199,6 +215,41 @@ fn regression_forecaster_inspectable_contract() {
     );
     assert_finite_scalars("RegressionForecaster", &e);
     assert_spine("RegressionForecaster", &e);
+}
+
+#[cfg(feature = "distributional")]
+#[test]
+fn laplace_inspectable_contract() {
+    use anofox_forecast::models::LaplaceForecaster;
+
+    let ts = make_seasonal_series(120, 12);
+    let mut model = LaplaceForecaster::new();
+    assert!(model.explanation().is_err());
+    model.fit(&ts).unwrap();
+    let e = model.explanation().unwrap();
+    match &e {
+        Explanation::Laplace(x) => {
+            assert!(!x.leaf_names.is_empty(), "Laplace: leaf_names empty");
+            assert_eq!(
+                x.leaf_names.len(),
+                x.leaf_weights.len(),
+                "Laplace: leaf_names/weights length mismatch"
+            );
+            assert!(!x.horizon_dists.is_empty(), "Laplace: horizon_dists empty");
+            assert!(!x.fitted_values.is_empty(), "Laplace: fitted_values empty");
+            assert_eq!(
+                x.fitted_values.len(),
+                x.residuals.len(),
+                "Laplace: fitted/residuals length mismatch"
+            );
+            let ws: f64 = x.leaf_weights.iter().sum();
+            assert!(
+                (ws - 1.0).abs() < 1e-9,
+                "Laplace: leaf_weights don't sum to 1"
+            );
+        }
+        other => panic!("expected Explanation::Laplace, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds an alpha `LaplaceForecaster` behind a new `distributional` feature flag: streaming, likelihood-weighted mixture over three cheap leaves (EMA, drift, AR(1)) that emits a `GaussianMixture` per horizon rather than a point forecast. Inspired by the shell design in [`microprediction/skaters`](https://github.com/microprediction/skaters); the full skaters ensemble (Holt, fractional-differencing, seasonal, Yeo-Johnson, OU mean-reversion, CRPS-tuned terminal leaf) is intentionally deferred to keep the port scope small and let the empirics be validated on real panel data before we commit further.

## New public surface

- `models::laplace::{Gaussian, GaussianMixture}` — distribution primitives with `mean`/`std`/`quantile`/`logpdf`/`cdf`.
- `models::laplace::Leaf` — streaming per-horizon predictor unit.
- `models::laplace::LaplaceForecaster` — implements `Forecaster` (point = mixture mean), `Inspectable` (`Explanation::Laplace(_)`), and the new `DistributionalForecaster` trait.
- `models::laplace::DistributionalForecaster: Forecaster` — object-safe sibling trait exposing `forecast_dist(&self, horizon) -> Result<Vec<GaussianMixture>>`. Point forecasters remain on `Forecaster` alone.
- `models::LaplaceExplanation` — payload with `horizon_dists`, `leaf_weights`, `leaf_names`, `fitted_values`, `residuals`.

The `Explanation` enum gained a `#[cfg(feature = "distributional")] Laplace(LaplaceExplanation)` variant; the #107 conformance suite covers it.

## Backward compatibility

Additive under a feature flag — default builds are unaffected. The module and enum variant only compile when the `distributional` feature is enabled.

## Test plan

- [x] `cargo check --lib` (default features) — clean
- [x] `cargo check --lib --features distributional` — clean
- [x] `cargo test --lib --features distributional` — 2890 passed
- [x] `cargo test --lib` — 2873 passed
- [x] `cargo test --tests --features distributional` — all integration tests green (includes the extended #107 conformance case)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --features distributional -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)