### PR TITLE
fix(ci): derive npm dist-tag from release ref name to allow prereleases

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -113,10 +113,24 @@ jobs:
         working-directory: js
         run: npm publish --access public --dry-run
 
+      # Derive the dist-tag from the release tag name (e.g. v0.12.0-alpha.1 →
+      # `alpha`; v0.12.0-beta.3 → `beta`; v1.0.0 → `latest`). npm 11 requires
+      # `--tag` on prerelease versions, and defaulting to `latest` on stable
+      # releases keeps installs on `npm install @sipemu/anofox-forecast`
+      # tracking the newest GA.
       - name: Publish to npm
         if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
         working-directory: js
-        run: npm publish --access public --provenance
+        run: |
+          ref="${GITHUB_REF_NAME:-}"
+          case "$ref" in
+            *-alpha*) tag=alpha ;;
+            *-beta*)  tag=beta  ;;
+            *-rc*)    tag=rc    ;;
+            *)        tag=latest ;;
+          esac
+          echo "Publishing with npm dist-tag: $tag (from ref '$ref')"
+          npm publish --access public --provenance --tag "$tag"
 
   test-wasm:
     name: Test WASM


### PR DESCRIPTION
## Summary

npm 11 refuses to publish a prerelease version without an explicit `--tag`, which broke the v0.12.0-alpha.1 release publish ([failed run](https://github.com/sipemu/anofox-forecast/actions/runs/28784402718)).

Infers the dist-tag from the release tag ref:

- `v*-alpha*` → `alpha`
- `v*-beta*` → `beta`
- `v*-rc*` → `rc`
- otherwise → `latest`

Stable releases still land on `latest`, so `npm install @sipemu/anofox-forecast` keeps tracking GA. Prereleases become discoverable via `npm install @sipemu/anofox-forecast@alpha` etc.

## Test plan

- [x] Merge → re-run the failed [npm publish job](https://github.com/sipemu/anofox-forecast/actions/runs/28784402718) → confirm `@sipemu/anofox-forecast@0.12.0-alpha.1` is live on npm with dist-tag `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)