### PR TITLE
Release v0.12.0-alpha.2: seasonal-EMA leaf for LaplaceForecaster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.2] - 2026-07-06
+
+### Added
+
+- **Seasonal-EMA leaf for `LaplaceForecaster`** (opt-in via `LaplaceForecaster::new().with_seasonal(period)`). Maintains one EMA per phase `k ∈ 0..period`; the h-step forecast reads phase `(now + h - 1) mod period`. Unseen phases fall back to a global EMA so short-history fits don't emit `NaN`. Period is caller-supplied (no auto-detection). `with_seasonal(0)` / `with_seasonal(1)` is a no-op.
+- New public: `models::laplace::leaves::SeasonalEmaLeaf`.
+- `LaplaceForecaster::seasonal_alpha(alpha)` builder to override the seasonal leaf's smoothing rate (default 0.15).
+- `examples/skaters_m5_benchmark.rs` (added in [#144](https://github.com/sipemu/anofox-forecast/pull/144)) now runs both the plain and `with_seasonal(7)` configurations.
+
+### Benchmark
+
+On the M5 top-1000 panel (999 non-intermittent series, 28-day horizon, weekly seasonality):
+
+| model | MAE (median) | MAE (mean) | vs. AutoETS winrate | fit time |
+|---|---|---|---|---|
+| Laplace (plain) | 5.46 | 7.05 | 0.368 | 0.24 s |
+| **Laplace+seasonal7** | **5.15** | **6.70** | **0.466** | **0.24 s** |
+| AutoETS | 4.77 | 6.23 | — | 26.1 s |
+
+One additional leaf closed ~40% of the MAE gap and +9.8 pp of winrate against AutoETS at zero fit-time cost. Laplace+seasonal7 beats plain Laplace on 91% of series — the leaf is doing real work.
+
+### Notes
+
+Alpha surface — additive behind the `distributional` feature. `LaplaceForecaster::new()` still produces the 3-leaf shell; the seasonal leaf must be requested explicitly.
+
 ## [0.12.0-alpha.1] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.12.0-alpha.1"
+anofox-forecast = "0.12.0-alpha.2"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.12.0-alpha.1",
+  "version": "0.12.0-alpha.2",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/examples/skaters_m5_benchmark.rs
+++ b/examples/skaters_m5_benchmark.rs
@@ -1,8 +1,10 @@
 //! Distributional-shell (skaters/laplace-style) accuracy benchmark on M5.
 //!
-//! Runs `LaplaceForecaster` (v0.12 alpha, `distributional` feature) against
-//! the point-forecast stack (`AutoETS`, `AutoTheta`) on the M5 top-1000
-//! retail panel. Reports:
+//! Runs two `LaplaceForecaster` configurations (v0.12 alpha,
+//! `distributional` feature) — the plain 3-leaf shell and the 4-leaf
+//! `with_seasonal(7)` variant that adds a weekly-seasonal-EMA leaf —
+//! against the point-forecast stack (`AutoETS`, `AutoTheta`) on the M5
+//! top-1000 retail panel. Reports:
 //!
 //! * per-series MAE on a 28-day held-out window (median + winrates)
 //! * empirical 90% interval coverage for the distributional model
@@ -112,6 +114,8 @@ fn main() {
     let mut theta_results: Vec<SeriesResult> = Vec::new();
     #[cfg(feature = "distributional")]
     let mut laplace_results: Vec<SeriesResult> = Vec::new();
+    #[cfg(feature = "distributional")]
+    let mut laplace_seasonal_results: Vec<SeriesResult> = Vec::new();
 
     let global_start = Instant::now();
 
@@ -144,10 +148,20 @@ fn main() {
             theta_results.push(r);
         }
 
-        // LaplaceForecaster (distributional-only branch)
+        // LaplaceForecaster (no seasonal leaf) — baseline shell.
         #[cfg(feature = "distributional")]
-        if let Some(r) = run_laplace(&train_ts, test_values) {
+        if let Some(r) = run_laplace(LaplaceForecaster::new(), &train_ts, test_values) {
             laplace_results.push(r);
+        }
+
+        // LaplaceForecaster with weekly-seasonal leaf (M5 has period 7).
+        #[cfg(feature = "distributional")]
+        if let Some(r) = run_laplace(
+            LaplaceForecaster::new().with_seasonal(7),
+            &train_ts,
+            test_values,
+        ) {
+            laplace_seasonal_results.push(r);
         }
     }
 
@@ -162,13 +176,24 @@ fn main() {
         summarize("AutoTheta", &theta_results),
     ];
     #[cfg(feature = "distributional")]
-    summaries.push(summarize("LaplaceForecaster", &laplace_results));
+    {
+        summaries.push(summarize("LaplaceForecaster", &laplace_results));
+        summaries.push(summarize(
+            "LaplaceForecaster+seasonal7",
+            &laplace_seasonal_results,
+        ));
+    }
 
     print_summary(&summaries);
 
     // Win-rate matrix: pairwise, per-series, on the intersection.
     #[cfg(feature = "distributional")]
-    print_pairwise(&ets_results, &theta_results, &laplace_results);
+    print_pairwise(
+        &ets_results,
+        &theta_results,
+        &laplace_results,
+        &laplace_seasonal_results,
+    );
 }
 
 fn run_point<F: Forecaster>(
@@ -196,9 +221,12 @@ fn run_point<F: Forecaster>(
 }
 
 #[cfg(feature = "distributional")]
-fn run_laplace(train: &TimeSeries, test: &[f64]) -> Option<SeriesResult> {
+fn run_laplace(
+    mut model: LaplaceForecaster,
+    train: &TimeSeries,
+    test: &[f64],
+) -> Option<SeriesResult> {
     let t0 = Instant::now();
-    let mut model = LaplaceForecaster::new();
     if model.fit(train).is_err() {
         return None;
     }
@@ -327,8 +355,17 @@ fn print_summary(summaries: &[ModelSummary]) {
 }
 
 #[cfg(feature = "distributional")]
-fn print_pairwise(ets: &[SeriesResult], theta: &[SeriesResult], laplace: &[SeriesResult]) {
-    let n = ets.len().min(theta.len()).min(laplace.len());
+fn print_pairwise(
+    ets: &[SeriesResult],
+    theta: &[SeriesResult],
+    laplace: &[SeriesResult],
+    laplace_seasonal: &[SeriesResult],
+) {
+    let n = ets
+        .len()
+        .min(theta.len())
+        .min(laplace.len())
+        .min(laplace_seasonal.len());
     if n == 0 {
         return;
     }
@@ -345,29 +382,26 @@ fn print_pairwise(ets: &[SeriesResult], theta: &[SeriesResult], laplace: &[Serie
         "\n=== Pairwise MAE win-rate on {} matched series (row beats column) ===",
         n
     );
-    println!(
-        "{:<22}{:>14}{:>14}{:>18}",
-        "", "AutoETS", "AutoTheta", "LaplaceForecaster"
-    );
-    println!(
-        "{:<22}{:>14}{:>14.3}{:>18.3}",
-        "AutoETS",
-        "-",
-        winrate(ets, theta),
-        winrate(ets, laplace)
-    );
-    println!(
-        "{:<22}{:>14.3}{:>14}{:>18.3}",
-        "AutoTheta",
-        winrate(theta, ets),
-        "-",
-        winrate(theta, laplace)
-    );
-    println!(
-        "{:<22}{:>14.3}{:>14.3}{:>18}",
-        "LaplaceForecaster",
-        winrate(laplace, ets),
-        winrate(laplace, theta),
-        "-"
-    );
+    let cols: [(&str, &[SeriesResult]); 4] = [
+        ("AutoETS", ets),
+        ("AutoTheta", theta),
+        ("Laplace", laplace),
+        ("Laplace+seas7", laplace_seasonal),
+    ];
+    print!("{:<22}", "");
+    for (name, _) in cols.iter() {
+        print!("{:>16}", name);
+    }
+    println!();
+    for (row_name, row) in cols.iter() {
+        print!("{:<22}", row_name);
+        for (col_name, col) in cols.iter() {
+            if row_name == col_name {
+                print!("{:>16}", "-");
+            } else {
+                print!("{:>16.3}", winrate(row, col));
+            }
+        }
+        println!();
+    }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.12.0-alpha.1",
+  "version": "0.12.0-alpha.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -15,17 +15,21 @@ use crate::models::traits::{validate_series_complete, Forecaster};
 use super::dist::GaussianMixture;
 use super::ensemble::{blend_horizon, softmax};
 use super::leaf::Leaf;
-use super::leaves::{Ar1Leaf, DriftLeaf, EmaLeaf};
+use super::leaves::{Ar1Leaf, DriftLeaf, EmaLeaf, SeasonalEmaLeaf};
 use super::DistributionalForecaster;
 
 /// Distributional forecaster returning a `GaussianMixture` per horizon.
 ///
 /// Wraps three streaming leaves (EMA, drift, AR(1)) and mixes them by
-/// cumulative one-step log-likelihood.
+/// cumulative one-step log-likelihood. Optionally includes a seasonal-EMA
+/// leaf when a period is supplied via [`Self::with_seasonal`] — pass the
+/// period explicitly (no auto-detection).
 pub struct LaplaceForecaster {
     ema_alpha: f64,
     drift_alpha: f64,
     ar_alpha_mean: f64,
+    seasonal_period: Option<usize>,
+    seasonal_alpha: f64,
 
     leaves: Vec<Box<dyn Leaf + Send>>,
     cum_log_liks: Vec<f64>,
@@ -37,7 +41,8 @@ pub struct LaplaceForecaster {
 }
 
 impl LaplaceForecaster {
-    /// Default configuration: EMA α=0.2, drift α=0.1, AR(1) mean α=0.1.
+    /// Default configuration: EMA α=0.2, drift α=0.1, AR(1) mean α=0.1;
+    /// no seasonal leaf.
     pub fn new() -> Self {
         Self::with_alphas(0.2, 0.1, 0.1)
     }
@@ -47,6 +52,8 @@ impl LaplaceForecaster {
             ema_alpha,
             drift_alpha,
             ar_alpha_mean,
+            seasonal_period: None,
+            seasonal_alpha: 0.15,
             leaves: Vec::new(),
             cum_log_liks: Vec::new(),
             n_obs: 0,
@@ -56,13 +63,33 @@ impl LaplaceForecaster {
         }
     }
 
+    /// Add a seasonal-EMA leaf with the caller-supplied period. A period
+    /// of 0 or 1 is treated as "no seasonal leaf" — no runtime error.
+    pub fn with_seasonal(mut self, period: usize) -> Self {
+        if period >= 2 {
+            self.seasonal_period = Some(period);
+        }
+        self
+    }
+
+    /// Override the smoothing rate for the seasonal-EMA leaf. Only meaningful
+    /// after `with_seasonal(period)` has been called. Clamped by the leaf.
+    pub fn seasonal_alpha(mut self, alpha: f64) -> Self {
+        self.seasonal_alpha = alpha;
+        self
+    }
+
     fn init_leaves(&mut self) {
-        self.leaves = vec![
+        let mut leaves: Vec<Box<dyn Leaf + Send>> = vec![
             Box::new(EmaLeaf::new(self.ema_alpha)),
             Box::new(DriftLeaf::new(self.drift_alpha)),
             Box::new(Ar1Leaf::new(self.ar_alpha_mean)),
         ];
-        self.cum_log_liks = vec![0.0; self.leaves.len()];
+        if let Some(p) = self.seasonal_period {
+            leaves.push(Box::new(SeasonalEmaLeaf::new(p, self.seasonal_alpha)));
+        }
+        self.cum_log_liks = vec![0.0; leaves.len()];
+        self.leaves = leaves;
     }
 
     fn weights(&self) -> Vec<f64> {
@@ -319,6 +346,69 @@ mod tests {
                 assert_eq!(e.fitted_values.len(), e.residuals.len());
                 assert_eq!(e.horizon_dists.len(), 8);
             }
+            other => panic!("expected Explanation::Laplace, got {other:?}"),
+        }
+    }
+
+    fn ts_seasonal(n: usize, period: usize) -> TimeSeries {
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let vals: Vec<f64> = (0..n)
+            .map(|i| {
+                10.0 * (2.0 * std::f64::consts::PI * (i % period) as f64 / period as f64).sin()
+                    + 50.0
+            })
+            .collect();
+        let stamps: Vec<_> = (0..n).map(|i| base + Duration::hours(i as i64)).collect();
+        TimeSeries::univariate(stamps, vals).unwrap()
+    }
+
+    #[test]
+    fn with_seasonal_adds_seasonal_leaf_and_helps_periodic_series() {
+        let ts = ts_seasonal(240, 12);
+        let mut plain = LaplaceForecaster::new();
+        let mut seasonal = LaplaceForecaster::new().with_seasonal(12);
+        plain.fit(&ts).unwrap();
+        seasonal.fit(&ts).unwrap();
+
+        match Inspectable::explanation(&seasonal).unwrap() {
+            Explanation::Laplace(e) => {
+                assert_eq!(e.leaf_names, vec!["ema", "drift", "ar1", "seasonal_ema"]);
+                assert_eq!(e.leaf_weights.len(), 4);
+            }
+            other => panic!("expected Explanation::Laplace, got {other:?}"),
+        }
+
+        // On a pure periodic series the seasonal fitted residual should be
+        // smaller than the plain fitted residual (mean absolute residual).
+        let plain_mae: f64 = plain
+            .residuals()
+            .unwrap()
+            .iter()
+            .map(|r| r.abs())
+            .sum::<f64>()
+            / plain.residuals().unwrap().len() as f64;
+        let seasonal_mae: f64 = seasonal
+            .residuals()
+            .unwrap()
+            .iter()
+            .map(|r| r.abs())
+            .sum::<f64>()
+            / seasonal.residuals().unwrap().len() as f64;
+        assert!(
+            seasonal_mae < plain_mae,
+            "seasonal MAR ({}) should beat plain MAR ({}) on a pure periodic series",
+            seasonal_mae,
+            plain_mae
+        );
+    }
+
+    #[test]
+    fn with_seasonal_period_lt_2_is_a_no_op() {
+        let ts = ts_ar1(100, 0.4);
+        let mut f = LaplaceForecaster::new().with_seasonal(1);
+        f.fit(&ts).unwrap();
+        match Inspectable::explanation(&f).unwrap() {
+            Explanation::Laplace(e) => assert_eq!(e.leaf_names.len(), 3),
             other => panic!("expected Explanation::Laplace, got {other:?}"),
         }
     }

--- a/src/models/laplace/leaves/mod.rs
+++ b/src/models/laplace/leaves/mod.rs
@@ -3,7 +3,9 @@
 mod ar;
 mod drift;
 mod ema;
+mod seasonal_ema;
 
 pub use ar::Ar1Leaf;
 pub use drift::DriftLeaf;
 pub use ema::EmaLeaf;
+pub use seasonal_ema::SeasonalEmaLeaf;

--- a/src/models/laplace/leaves/seasonal_ema.rs
+++ b/src/models/laplace/leaves/seasonal_ema.rs
@@ -1,0 +1,163 @@
+//! Seasonal-EMA leaf.
+//!
+//! Maintains a per-phase EMA of the level: for a series with period `p`,
+//! phase `k ∈ 0..p` gets its own exponentially-weighted mean. The h-step
+//! forecast at phase `(now + h) mod p` reads that phase's EMA; unseen
+//! phases (cold-start of the calendar cycle) fall back to a global EMA.
+//!
+//! Predictive std grows as `σ · √h` where `σ²` is running residual
+//! variance on the phase-matched prediction — same convention as the
+//! other leaves.
+//!
+//! The period is supplied by the caller — no auto-detection.
+
+use crate::models::laplace::dist::Gaussian;
+use crate::models::laplace::leaf::Leaf;
+
+pub struct SeasonalEmaLeaf {
+    period: usize,
+    alpha: f64,
+    phase_level: Vec<f64>,
+    phase_seen: Vec<bool>,
+    phase_step: usize,
+    global_ema: f64,
+    n: usize,
+    ss: f64,
+    mean_resid: f64,
+}
+
+impl SeasonalEmaLeaf {
+    pub fn new(period: usize, alpha: f64) -> Self {
+        let period = period.max(1);
+        Self {
+            period,
+            alpha: alpha.clamp(1e-3, 1.0 - 1e-3),
+            phase_level: vec![0.0; period],
+            phase_seen: vec![false; period],
+            phase_step: 0,
+            global_ema: 0.0,
+            n: 0,
+            ss: 0.0,
+            mean_resid: 0.0,
+        }
+    }
+
+    pub fn period(&self) -> usize {
+        self.period
+    }
+
+    fn sigma(&self) -> f64 {
+        if self.n < 2 {
+            return 1.0;
+        }
+        (self.ss / (self.n as f64 - 1.0)).sqrt().max(1e-9)
+    }
+
+    fn level_for_phase(&self, phase: usize) -> f64 {
+        if self.phase_seen[phase] {
+            self.phase_level[phase]
+        } else {
+            self.global_ema
+        }
+    }
+}
+
+impl Leaf for SeasonalEmaLeaf {
+    fn name(&self) -> &'static str {
+        "seasonal_ema"
+    }
+
+    fn predict(&self, horizon: usize) -> Vec<Gaussian> {
+        let base = self.sigma();
+        (1..=horizon)
+            .map(|h| {
+                let phase = (self.phase_step + h - 1) % self.period;
+                Gaussian::new(self.level_for_phase(phase), base * (h as f64).sqrt())
+            })
+            .collect()
+    }
+
+    fn observe(&mut self, y: f64) {
+        let phase = self.phase_step;
+        let predicted = self.level_for_phase(phase);
+        let resid = y - predicted;
+        self.n += 1;
+        let delta = resid - self.mean_resid;
+        self.mean_resid += delta / self.n as f64;
+        self.ss += delta * (resid - self.mean_resid);
+
+        if self.phase_seen[phase] {
+            self.phase_level[phase] = self.alpha * y + (1.0 - self.alpha) * self.phase_level[phase];
+        } else {
+            self.phase_level[phase] = y;
+            self.phase_seen[phase] = true;
+        }
+
+        if self.n == 1 {
+            self.global_ema = y;
+        } else {
+            self.global_ema = self.alpha * y + (1.0 - self.alpha) * self.global_ema;
+        }
+
+        self.phase_step = (self.phase_step + 1) % self.period;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locks_onto_pure_period_signal() {
+        // Repeat [10, 20, 30] many times → phase EMAs converge to those.
+        let cycle = [10.0, 20.0, 30.0];
+        let mut leaf = SeasonalEmaLeaf::new(3, 0.4);
+        for _ in 0..200 {
+            for &y in &cycle {
+                leaf.observe(y);
+            }
+        }
+        let preds = leaf.predict(3);
+        assert!(
+            (preds[0].mean - 10.0).abs() < 0.5,
+            "h=1 → {}",
+            preds[0].mean
+        );
+        assert!(
+            (preds[1].mean - 20.0).abs() < 0.5,
+            "h=2 → {}",
+            preds[1].mean
+        );
+        assert!(
+            (preds[2].mean - 30.0).abs() < 0.5,
+            "h=3 → {}",
+            preds[2].mean
+        );
+    }
+
+    #[test]
+    fn cold_start_uses_global_ema_for_unseen_phases() {
+        let mut leaf = SeasonalEmaLeaf::new(4, 0.4);
+        // Only feed 2 observations — phases 2 and 3 are unseen.
+        leaf.observe(5.0);
+        leaf.observe(7.0);
+        let preds = leaf.predict(4);
+        // preds[2] and preds[3] should be finite and near the observed range,
+        // not NaN, because global_ema fallback applies.
+        for (i, p) in preds.iter().enumerate() {
+            assert!(p.mean.is_finite(), "h={}: mean not finite", i + 1);
+            assert!(p.std.is_finite() && p.std > 0.0, "h={}: std invalid", i + 1);
+        }
+    }
+
+    #[test]
+    fn period_one_degenerates_to_plain_ema() {
+        let mut seasonal = SeasonalEmaLeaf::new(1, 0.3);
+        for y in [1.0, 2.0, 3.0, 4.0, 5.0] {
+            seasonal.observe(y);
+        }
+        // Both horizons should give the same mean (period=1 → always same phase).
+        let preds = seasonal.predict(2);
+        assert!((preds[0].mean - preds[1].mean).abs() < 1e-12);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a fourth leaf to `LaplaceForecaster` — an opt-in per-phase seasonal-EMA — plus a benchmark rerun that quantifies its impact and a version bump to `0.12.0-alpha.2`.

## New public surface

- `LaplaceForecaster::new().with_seasonal(period)` — adds a per-phase EMA leaf. Period supplied by caller (no auto-detection); `period < 2` is a no-op.
- `LaplaceForecaster::seasonal_alpha(alpha)` — overrides the seasonal leaf's smoothing rate (default 0.15).
- `models::laplace::leaves::SeasonalEmaLeaf` — the leaf itself.

Existing `LaplaceForecaster::new()` remains the 3-leaf shell.

## Leaf math

Maintains one EMA per phase `k ∈ 0..period`. The h-step forecast reads `phase_ema[(now + h - 1) mod period]`; unseen phases (cold start of the calendar cycle) fall back to a global EMA so short-history fits don't emit `NaN`. Predictive std uses running residual variance on the phase-matched prediction — same convention as EMA/drift/AR leaves.

## Benchmark impact (M5 top-1000, 999 non-intermittent series, 28-day horizon, weekly seasonality)

| model | MAE (median) | MAE (mean) | vs. AutoETS winrate | 90% coverage | fit time |
|---|---|---|---|---|---|
| Laplace (plain) | 5.46 | 7.05 | 0.368 | 0.961 | 0.24 s |
| **Laplace+seasonal7** | **5.15** | **6.70** | **0.466** | 0.969 | **0.24 s** |
| AutoETS | 4.77 | 6.23 | — | – | 26.1 s |
| AutoTheta | 4.77 | 6.23 | — | – | 27.7 s |

Pairwise MAE winrate (row beats column):

|  | AutoETS | AutoTheta | Laplace | Laplace+seas7 |
|---|---|---|---|---|
| AutoETS | – | 0.473 | 0.632 | 0.534 |
| AutoTheta | 0.503 | – | 0.630 | 0.533 |
| Laplace | 0.368 | 0.370 | – | 0.094 |
| **Laplace+seas7** | **0.466** | **0.467** | **0.906** | – |

**One additional leaf closed ~40% of the MAE gap and +9.8 pp of winrate against AutoETS at zero fit-time cost.** Laplace+seasonal7 wins on 91% of series against plain Laplace — the leaf is doing real work.

## Decision signal on plan 2

Meaningful. Adding one leaf moved the shell from "loses 63/37" to "loses 53/47" against AutoETS. Each incremental leaf can be independently benchmarked via this harness, which is exactly the empirical loop I said we'd use to decide plan 2 from evidence, not from the paper.

Suggested next leaves, in order of expected marginal impact:

1. Holt (level + trend + damping) — closes the gap for series with sustained non-constant trend
2. Fractional-differencing / long-memory — a class of series where AR(1) underfits
3. OU mean-reversion — for series with genuine mean reversion around a level

Each should be a small PR + benchmark rerun.

## Notes

- Alpha surface: additive behind `distributional` feature. `LaplaceForecaster::new()` still produces the 3-leaf shell.
- Version bump: `0.12.0-alpha.1` → `0.12.0-alpha.2` (Cargo, wasm crate, npm package, README).
- CHANGELOG entry added.

## Test plan

- [x] `cargo test --lib --features distributional laplace` → 22 passed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --features distributional -- -D warnings` clean
- [x] `SAMPLE_SIZE=1000 cargo run --release --features distributional --example skaters_m5_benchmark` — numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)