### PR TITLE
Release v0.12.0-alpha.6: opt-in Yeo-Johnson variance stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.6] - 2026-07-06
+
+### Added
+
+- **Yeo-Johnson power transform on `LaplaceForecaster`** — opt-in via `LaplaceForecaster::new().with_yeo_johnson(lambda)` (user λ) or `.with_yeo_johnson_mle()` (MLE at fit start, uses the crate's existing `transform::yeo_johnson::yeo_johnson_lambda`). All leaves see transformed values; forecasts inverse-transformed via the delta method (`mean_orig = yj_inverse(mean_trans, λ)`, `σ_orig = σ_trans · |dy/dz|`). Component means are clamped to the observed training range in transformed space before inversion — the log-branch Jacobian explodes exponentially on extrapolation and even one runaway series destroys mean MAE.
+- New public: `LaplaceForecaster::with_yeo_johnson`, `.with_yeo_johnson_mle`, `.yeo_johnson_lambda()`.
+
+### Benchmark: coverage wins big, MAE/logpdf regress
+
+M5 top-1000 (adding YJ to the best `Laplace+AR2+S7` config):
+
+| variant | MAE (median) | MAE (mean) | cover@90 (target 0.90) | logpdf (avg) | fit time |
+|---|---|---|---|---|---|
+| Laplace + AR2 + S7 | 5.09 | 6.64 | 0.970 | −3.824 | 0.38 s |
+| Laplace + AR2 + S7 + Cal | 5.09 | 6.64 | 0.966 | −3.773 | 0.46 s |
+| **Laplace + AR2 + S7 + YJ** | 5.10 | 7.29 | **0.935** | −4.325 | 15.3 s |
+| Laplace + AR2 + S7 + YJ + Cal | 5.10 | 7.29 | 0.936 | −4.343 | 15.4 s |
+
+- **Coverage moved 3.5 pp toward target** (0.970 → 0.935) — the variance-stabilization the transform is designed for, and 8× larger than what alpha-5 calibration alone could do (0.4 pp).
+- **Mean MAE regressed 10%** (6.64 → 7.29) even with the training-range clamp — the delta-method inverse skews component means for horizons where leaves extrapolate.
+- **Logpdf regressed 0.5** — the delta-method Gaussian mixture in original space is a coarser approximation of the true (skewed) inverse-transformed distribution. For proper logpdf we'd need to evaluate density in transformed space and add the `log|dz/dy|` Jacobian correction; deferred.
+- **Fit time 40× slower** (0.38 s → 15.3 s) — the MLE grid searches 401 λ values × O(n) transforms per fit. Fixed-λ (`with_yeo_johnson(λ)`) skips this and matches the base fit time.
+- Median MAE essentially unchanged (5.09 → 5.10).
+
+### Notes
+
+Ship-worthy as an opt-in tool for coverage-critical use cases (safety-stock sizing, threshold anomaly detection) — but not the default and not a universal MAE win. Combining YJ with alpha-5 calibration is a small net regression, not composition: coverage stays at 0.936 (barely above YJ alone), logpdf gets slightly worse. Recommend YJ alone or Cal alone, not both, for now.
+
+### Future work (deferred to a later alpha)
+
+**Coordinate-grid ensemble** — instead of one λ from MLE, run each leaf against a small λ grid (`{-1, 0, 0.5, 1, 1.5}`) and let the softmax weight each (leaf, λ) candidate. Skaters' actual design. Likely fixes both the MAE regression (bad λ candidates get low weight) and the fit-time cost (per-fit λ MLE avoided). Larger shell-level change; not this alpha.
+
 ## [0.12.0-alpha.5] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.12.0-alpha.5"
+version = "0.12.0-alpha.6"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.5"
+version = "0.12.0-alpha.6"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.12.0-alpha.5"
+version = "0.12.0-alpha.6"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.12.0-alpha.5"
+anofox-forecast = "0.12.0-alpha.6"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.5"
+version = "0.12.0-alpha.6"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.12.0-alpha.5",
+  "version": "0.12.0-alpha.6",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/examples/skaters_m5_benchmark.rs
+++ b/examples/skaters_m5_benchmark.rs
@@ -120,10 +120,10 @@ fn main() {
 
     let base_date = timestamps[0];
 
-    // Slot layout: 0=AutoETS, 1=AutoTheta, 2=Laplace, 3=Laplace+H,
-    // 4=Laplace+AR2, 5=Laplace+S7, 6=Laplace+AR2+S7, 7=Laplace+AR2+S7+Cal.
-    // Keeping this stable so the pairwise matrix and summary lines match.
-    const N_MODELS: usize = 8;
+    // Slot layout stable so the pairwise matrix and summary lines match:
+    //   0=AutoETS, 1=AutoTheta, 2=Laplace, 3=Laplace+H, 4=Laplace+AR2,
+    //   5=Laplace+S7, 6=Laplace+AR2+S7, 7=+Cal, 8=+YJ, 9=+YJ+Cal.
+    const N_MODELS: usize = 10;
     let labels: [&str; N_MODELS] = [
         "AutoETS",
         "AutoTheta",
@@ -133,6 +133,8 @@ fn main() {
         "Laplace+S7",
         "Laplace+AR2+S7",
         "Laplace+AR2+S7+Cal",
+        "Laplace+AR2+S7+YJ",
+        "Laplace+AR2+S7+YJ+Cal",
     ];
     let mut results: Vec<Vec<SeriesResult>> = (0..N_MODELS).map(|_| Vec::new()).collect();
     let mut characteristics: Vec<Characteristics> = Vec::new();
@@ -173,7 +175,7 @@ fn main() {
 
         #[cfg(feature = "distributional")]
         {
-            let cfgs: [(usize, LaplaceForecaster); 6] = [
+            let cfgs: [(usize, LaplaceForecaster); 8] = [
                 (2, LaplaceForecaster::new()),
                 (3, LaplaceForecaster::new().with_holt_defaults()),
                 (4, LaplaceForecaster::new().with_ar2_defaults()),
@@ -189,6 +191,21 @@ fn main() {
                     LaplaceForecaster::new()
                         .with_ar2_defaults()
                         .with_seasonal(7)
+                        .with_calibration(),
+                ),
+                (
+                    8,
+                    LaplaceForecaster::new()
+                        .with_ar2_defaults()
+                        .with_seasonal(7)
+                        .with_yeo_johnson_mle(),
+                ),
+                (
+                    9,
+                    LaplaceForecaster::new()
+                        .with_ar2_defaults()
+                        .with_seasonal(7)
+                        .with_yeo_johnson_mle()
                         .with_calibration(),
                 ),
             ];

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.12.0-alpha.5",
+  "version": "0.12.0-alpha.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -14,7 +14,62 @@ use crate::models::inspect::{Explanation, Inspectable, LaplaceExplanation};
 use crate::models::traits::{validate_series_complete, Forecaster};
 
 use super::dist::GaussianMixture;
+use crate::transform::yeo_johnson::yeo_johnson_lambda;
+
 use super::ensemble::{blend_horizon, softmax};
+
+/// Yeo-Johnson forward transform (scalar).
+#[inline]
+fn yj_forward(x: f64, lambda: f64) -> f64 {
+    if x >= 0.0 {
+        if lambda.abs() < 1e-12 {
+            (x + 1.0).ln()
+        } else {
+            ((x + 1.0).powf(lambda) - 1.0) / lambda
+        }
+    } else if (lambda - 2.0).abs() < 1e-12 {
+        -(-x + 1.0).ln()
+    } else {
+        -(((-x + 1.0).powf(2.0 - lambda)) - 1.0) / (2.0 - lambda)
+    }
+}
+
+/// Yeo-Johnson inverse (scalar). Returns `(x, |dx/dy|)` for delta-method
+/// std propagation. Saturates to the domain boundary and Jacobian = 0
+/// when the requested inverse is outside the definition (e.g. `λ · y + 1
+/// ≤ 0` on the positive branch).
+#[inline]
+fn yj_inverse_with_jac(y: f64, lambda: f64) -> (f64, f64) {
+    if y >= 0.0 {
+        if lambda.abs() < 1e-12 {
+            let ey = y.exp();
+            (ey - 1.0, ey)
+        } else {
+            let base = lambda * y + 1.0;
+            if base <= 0.0 {
+                (0.0, 0.0)
+            } else {
+                let inv_lambda = 1.0 / lambda;
+                let x = base.powf(inv_lambda) - 1.0;
+                let dxdy = base.powf(inv_lambda - 1.0);
+                (x, dxdy)
+            }
+        }
+    } else if (lambda - 2.0).abs() < 1e-12 {
+        let emy = (-y).exp();
+        (1.0 - emy, emy)
+    } else {
+        let base = 1.0 - (2.0 - lambda) * y;
+        if base <= 0.0 {
+            (1.0, 0.0)
+        } else {
+            let inv_c = 1.0 / (2.0 - lambda);
+            let x = 1.0 - base.powf(inv_c);
+            let dxdy = base.powf(inv_c - 1.0);
+            (x, dxdy)
+        }
+    }
+}
 use super::leaf::Leaf;
 use super::leaves::{Ar1Leaf, Ar2Leaf, DriftLeaf, EmaLeaf, HoltLeaf, SeasonalEmaLeaf};
 use super::DistributionalForecaster;
@@ -45,6 +100,11 @@ pub struct LaplaceForecaster {
     seasonal_period: Option<usize>,
     seasonal_alpha: f64,
     calibrate: bool,
+    /// User-supplied Yeo-Johnson λ. Overrides `yj_auto` when both are set.
+    yj_lambda: Option<f64>,
+    /// If true, fit the Yeo-Johnson λ via MLE at the start of `fit()` and
+    /// store it in `fitted_yj_lambda`.
+    yj_auto: bool,
 
     leaves: Vec<Box<dyn Leaf + Send>>,
     cum_log_liks: Vec<f64>,
@@ -53,12 +113,27 @@ pub struct LaplaceForecaster {
     fitted_values: Vec<f64>,
     residuals: Vec<f64>,
     training_values: Vec<f64>,
-    /// 1-step mixture std at each training step (for calibration).
+    /// 1-step mixture std at each training step (transformed space if YJ
+    /// is enabled, else original space). Used by [`Self::with_calibration`].
     predictive_stds: Vec<f64>,
-    /// Terminal scale factor: `1.0` when uncalibrated, else the empirical
-    /// residual std divided by the average 1-step mixture std. Applied to
-    /// every `GaussianMixture` component's std at forecast time.
+    /// 1-step residuals `y_trans - mixture_mean_trans` in the space the
+    /// leaves operate in. Kept alongside `predictive_stds` so the
+    /// calibration quantile-match uses matched-space `|z|`.
+    predictive_residuals_trans: Vec<f64>,
+    /// Terminal scale factor: `1.0` when uncalibrated. Applied to every
+    /// `GaussianMixture` component's std at forecast time — in transformed
+    /// space (before Yeo-Johnson inverse-transform).
     calibration_scale: f64,
+    /// The Yeo-Johnson λ actually used for this fit. `None` if YJ was
+    /// disabled. Populated even when the user supplied a fixed λ, so
+    /// downstream callers can inspect the transform.
+    fitted_yj_lambda: Option<f64>,
+    /// Observed range of training values in transformed space. Used to
+    /// clamp forecast-time transformed-space means before applying the
+    /// YJ inverse — the inverse's Jacobian explodes exponentially in the
+    /// log branch when a leaf's h-step forecast extrapolates far beyond
+    /// the training window. Empty when YJ is disabled.
+    yj_trans_range: Option<(f64, f64)>,
 }
 
 impl LaplaceForecaster {
@@ -78,6 +153,8 @@ impl LaplaceForecaster {
             seasonal_period: None,
             seasonal_alpha: 0.15,
             calibrate: false,
+            yj_lambda: None,
+            yj_auto: false,
             leaves: Vec::new(),
             cum_log_liks: Vec::new(),
             n_obs: 0,
@@ -85,8 +162,37 @@ impl LaplaceForecaster {
             residuals: Vec::new(),
             training_values: Vec::new(),
             predictive_stds: Vec::new(),
+            predictive_residuals_trans: Vec::new(),
             calibration_scale: 1.0,
+            fitted_yj_lambda: None,
+            yj_trans_range: None,
         }
+    }
+
+    /// Apply a Yeo-Johnson power transform with fixed λ before feeding
+    /// observations to the leaves. Predictions are delta-method
+    /// inverse-transformed back to original space at forecast time.
+    /// Variance-stabilizes retail-style panels where the residual scale
+    /// is proportional to level.
+    pub fn with_yeo_johnson(mut self, lambda: f64) -> Self {
+        self.yj_lambda = Some(lambda);
+        self.yj_auto = false;
+        self
+    }
+
+    /// Fit the Yeo-Johnson λ via MLE at the start of `fit()`. Uses the
+    /// crate's [`transform::yeo_johnson::yeo_johnson_lambda`] estimator
+    /// (grid search over `[-2, 2]` at Δ=0.01, refined at Δ=0.001).
+    pub fn with_yeo_johnson_mle(mut self) -> Self {
+        self.yj_auto = true;
+        self.yj_lambda = None;
+        self
+    }
+
+    /// The Yeo-Johnson λ actually used for this fit — `None` if YJ was
+    /// disabled or the model hasn't been fit yet.
+    pub fn yeo_johnson_lambda(&self) -> Option<f64> {
+        self.fitted_yj_lambda
     }
 
     /// Enable the terminal calibration step. After leaf-training, a single
@@ -201,10 +307,48 @@ impl Forecaster for LaplaceForecaster {
         } else {
             Vec::new()
         };
+        self.predictive_residuals_trans = if self.calibrate {
+            Vec::with_capacity(values.len())
+        } else {
+            Vec::new()
+        };
         self.calibration_scale = 1.0;
         self.n_obs = 0;
 
-        for &y in values {
+        // Resolve Yeo-Johnson λ. User-supplied wins over MLE; MLE happens
+        // exactly once at fit start over the full training window.
+        self.fitted_yj_lambda = if let Some(l) = self.yj_lambda {
+            Some(l)
+        } else if self.yj_auto {
+            Some(yeo_johnson_lambda(values))
+        } else {
+            None
+        };
+        let yj = self.fitted_yj_lambda;
+        // Cache the observed range of training values in transformed
+        // space — used to clamp forecast-time means before the inverse.
+        // Clamp to exact training range in transformed space. Any padding
+        // lets the inverse extrapolate; on the log-branch (λ near 0) even
+        // small extrapolation produces astronomical values.
+        self.yj_trans_range = yj.map(|l| {
+            let mut lo = f64::INFINITY;
+            let mut hi = f64::NEG_INFINITY;
+            for &v in values {
+                let t = yj_forward(v, l);
+                if t.is_finite() {
+                    lo = lo.min(t);
+                    hi = hi.max(t);
+                }
+            }
+            (lo, hi)
+        });
+
+        for &y_orig in values {
+            let y = match yj {
+                Some(l) => yj_forward(y_orig, l),
+                None => y_orig,
+            };
+
             // 1-step predictions from each leaf, before observing y.
             let per_leaf: Vec<super::dist::Gaussian> =
                 self.leaves.iter().map(|l| l.predict(1)[0]).collect();
@@ -212,19 +356,32 @@ impl Forecaster for LaplaceForecaster {
 
             let mixture =
                 GaussianMixture::new(weights.iter().zip(per_leaf.iter()).map(|(w, g)| (*w, *g)));
-            let fitted = if mixture.is_empty() {
-                y
+            // Fitted / residuals: expose in ORIGINAL space so downstream
+            // consumers (Explanation, tests, callers computing MAE) see
+            // the same scale as the training values.
+            let fitted_orig = if mixture.is_empty() {
+                y_orig
             } else {
-                mixture.mean()
+                let m_trans = mixture.mean();
+                match yj {
+                    Some(l) => yj_inverse_with_jac(m_trans, l).0,
+                    None => m_trans,
+                }
             };
-            self.fitted_values.push(fitted);
-            self.residuals.push(y - fitted);
+            self.fitted_values.push(fitted_orig);
+            self.residuals.push(y_orig - fitted_orig);
             if self.calibrate {
-                self.predictive_stds.push(if mixture.is_empty() {
-                    1.0
+                // Calibration operates on transformed-space residuals (the
+                // leaves' Gaussian assumption lives there); stash both the
+                // transformed-space 1-step σ and the transformed-space
+                // residual so quantile-match sees matched-space `|z|`.
+                let (mu_trans, sigma_trans) = if mixture.is_empty() {
+                    (y, 1.0)
                 } else {
-                    mixture.std()
-                });
+                    (mixture.mean(), mixture.std())
+                };
+                self.predictive_stds.push(sigma_trans);
+                self.predictive_residuals_trans.push(y - mu_trans);
             }
 
             // Score each leaf on this y, then absorb.
@@ -245,11 +402,14 @@ impl Forecaster for LaplaceForecaster {
         // metric (unlike a MoM variance match, which is fooled by bounded
         // or heavy-tailed panels where variance already matches but the
         // tail shape doesn't).
-        if self.calibrate && !self.residuals.is_empty() && !self.predictive_stds.is_empty() {
+        if self.calibrate
+            && !self.predictive_residuals_trans.is_empty()
+            && !self.predictive_stds.is_empty()
+        {
             const TARGET_LEVEL: f64 = 0.90;
             const GAUSSIAN_Z_AT_90: f64 = 1.644_853_626_951_472_7; // Φ⁻¹(0.95)
             let mut zabs: Vec<f64> = self
-                .residuals
+                .predictive_residuals_trans
                 .iter()
                 .zip(self.predictive_stds.iter())
                 .filter_map(|(r, s)| {
@@ -376,18 +536,32 @@ impl DistributionalForecaster for LaplaceForecaster {
         let weights = self.weights();
         let per_leaf = self.per_leaf_horizons(horizon);
         let scale = self.calibration_scale;
+        let yj = self.fitted_yj_lambda;
+        let trans_range = self.yj_trans_range;
         Ok((0..horizon)
             .map(|h| {
                 let m = blend_horizon(&weights, &per_leaf, h);
-                if (scale - 1.0).abs() < 1e-12 {
-                    m
-                } else {
-                    GaussianMixture::new(
-                        m.components
-                            .into_iter()
-                            .map(|(w, g)| (w, super::dist::Gaussian::new(g.mean, g.std * scale))),
-                    )
-                }
+                // Apply calibration scale in the leaves' space (transformed
+                // if YJ is active), then YJ inverse via delta method. Clamp
+                // component means to the observed training range in
+                // transformed space to prevent the log-branch Jacobian from
+                // exploding on far-horizon extrapolation.
+                let components = m.components.into_iter().map(|(w, g)| {
+                    let sigma_scaled = g.std * scale;
+                    let (mean_out, sigma_out) = match yj {
+                        Some(l) => {
+                            let mean_trans = match trans_range {
+                                Some((lo, hi)) => g.mean.clamp(lo, hi),
+                                None => g.mean,
+                            };
+                            let (m_orig, jac) = yj_inverse_with_jac(mean_trans, l);
+                            (m_orig, (sigma_scaled * jac.abs()).max(1e-9))
+                        }
+                        None => (g.mean, sigma_scaled),
+                    };
+                    (w, super::dist::Gaussian::new(mean_out, sigma_out))
+                });
+                GaussianMixture::new(components)
             })
             .collect())
     }
@@ -531,6 +705,52 @@ mod tests {
             seasonal_mae,
             plain_mae
         );
+    }
+
+    fn ts_positive_multiplicative(n: usize) -> TimeSeries {
+        // A positive series whose noise scales with level — the setting
+        // Yeo-Johnson is designed to help.
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let mut vals = Vec::with_capacity(n);
+        for i in 0..n {
+            let level = 50.0 + 0.1 * i as f64;
+            let noise = ((i as f64 * 12.9898).sin() * 43758.5453).fract() - 0.5;
+            vals.push(level * (1.0 + 0.3 * noise));
+        }
+        let stamps: Vec<_> = (0..n).map(|i| base + Duration::hours(i as i64)).collect();
+        TimeSeries::univariate(stamps, vals).unwrap()
+    }
+
+    #[test]
+    fn with_yeo_johnson_mle_finds_a_lambda_and_returns_original_scale() {
+        let ts = ts_positive_multiplicative(300);
+        let mut f = LaplaceForecaster::new().with_yeo_johnson_mle();
+        f.fit(&ts).unwrap();
+        let lambda = f.yeo_johnson_lambda().expect("YJ MLE should populate λ");
+        assert!(
+            lambda.is_finite() && (-2.0..=2.0).contains(&lambda),
+            "λ out of expected range: {}",
+            lambda
+        );
+        // Forecasts should come back in original scale (roughly around the
+        // series' level, not the transformed sub-unit region).
+        let dists = f.forecast_dist(3).unwrap();
+        for d in &dists {
+            let m = d.mean();
+            assert!(
+                m.is_finite() && m > 5.0,
+                "point forecast {} out of original scale",
+                m
+            );
+        }
+    }
+
+    #[test]
+    fn with_yeo_johnson_fixed_lambda_is_recorded() {
+        let ts = ts_ar1(200, 0.5);
+        let mut f = LaplaceForecaster::new().with_yeo_johnson(0.5);
+        f.fit(&ts).unwrap();
+        assert_eq!(f.yeo_johnson_lambda(), Some(0.5));
     }
 
     #[test]

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -181,8 +181,9 @@ impl LaplaceForecaster {
     }
 
     /// Fit the Yeo-Johnson λ via MLE at the start of `fit()`. Uses the
-    /// crate's [`transform::yeo_johnson::yeo_johnson_lambda`] estimator
-    /// (grid search over `[-2, 2]` at Δ=0.01, refined at Δ=0.001).
+    /// crate's [`crate::transform::yeo_johnson::yeo_johnson_lambda`]
+    /// estimator (grid search over `[-2, 2]` at Δ=0.01, refined at
+    /// Δ=0.001).
     pub fn with_yeo_johnson_mle(mut self) -> Self {
         self.yj_auto = true;
         self.yj_lambda = None;


### PR DESCRIPTION
Re-opened after #150 (alpha-5) merged (the original stacked PR #151 auto-closed with the base-branch delete).

Phase 2 of the roadmap.

## Summary

Adds an opt-in Yeo-Johnson power transform to `LaplaceForecaster`. All leaves see transformed values; forecasts inverse-transformed via the delta method (`mean_orig = yj_inverse(mean_trans, λ)`, `σ_orig = σ_trans · |dy/dz|`). Component means are clamped to the observed training range in transformed space — critical: without this, the log-branch Jacobian explodes exponentially on extrapolation and even one runaway series makes mean MAE catastrophically large.

## New public API

- `LaplaceForecaster::new().with_yeo_johnson(lambda)` — fixed λ, matches base fit cost.
- `LaplaceForecaster::new().with_yeo_johnson_mle()` — MLE at fit start via the crate's existing `yeo_johnson_lambda` estimator. 40× slower fits due to the 401-point grid search × O(n) transform per candidate.
- `LaplaceForecaster::yeo_johnson_lambda()` — inspection accessor.

## Honest benchmark result (M5 top-1000, 999 series, 28-day horizon)

Adding YJ+MLE to the best config from previous alphas:

| variant | MAE (median) | MAE (mean) | cover@90 (target 0.90) | logpdf (avg) | fit time |
|---|---|---|---|---|---|
| Laplace + AR2 + S7 | 5.09 | 6.64 | 0.970 | −3.824 | 0.38 s |
| Laplace + AR2 + S7 + Cal (alpha-5) | 5.09 | 6.64 | 0.966 | −3.773 | 0.46 s |
| **Laplace + AR2 + S7 + YJ** | 5.10 | 7.29 | **0.935** | −4.325 | 15.3 s |
| Laplace + AR2 + S7 + YJ + Cal | 5.10 | 7.29 | 0.936 | −4.343 | 15.4 s |

**Interpretation:**
- **Coverage moved 3.5 pp toward target** — 8× larger move than alpha-5 calibration alone. The variance-stabilization the transform is designed for.
- **Mean MAE regressed 10%** (6.64 → 7.29) even with training-range clamping — the delta-method inverse skews component means on horizons where leaves extrapolate.
- **Logpdf regressed 0.5** — the delta-method Gaussian mixture in original space is a coarser approximation of the true (skewed) inverse-transformed distribution.
- **Fit time 40× slower** — MLE grid search. Fixed-λ (`with_yeo_johnson(λ)`) skips this.
- Median MAE essentially unchanged.

## Ship recommendation

Ship as an **opt-in tool for coverage-critical use cases** (safety-stock sizing, threshold anomaly detection) with the tradeoffs documented. Not a default. Not a universal MAE win. Users should pick **YJ alone or Cal alone, not both** — combining them is a small net regression.

## Deferred to a later alpha: coordinate-grid ensemble

Instead of one λ picked by MLE, run each leaf against a small λ grid (`{-1, 0, 0.5, 1, 1.5}`) and let softmax weight each `(leaf, λ)` candidate — the actual skaters recipe. Likely fixes both the MAE regression (bad λ candidates get low weight) and the fit-time cost (per-fit MLE avoided). This is a shell-level rearrangement, ~1 week; kept out of this PR to keep the alpha-6 scope tight.

## Test plan

- [x] `cargo test --lib --features distributional laplace` → 34 passed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --features distributional -- -D warnings` clean
- [x] `SAMPLE_SIZE=1000 cargo run --release --features distributional --example skaters_m5_benchmark` — numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)