### PR TITLE
Release v0.12.0-alpha.7: opt-in hyperparameter-population leaf set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.7] - 2026-07-06
+
+### Added
+
+- **Hyperparameter-population leaf set for `LaplaceForecaster`** — opt-in via `LaplaceForecaster::new().with_populations()`. Replaces the 3-leaf default with a 7-leaf expansion in the same families: `EMA` at α ∈ {0.05, 0.20, 0.50}, `Drift` at α ∈ {0.05, 0.15}, `AR(1)` mean-EMA at α ∈ {0.05, 0.15}. The softmax-over-cumulative-log-lik weighting picks the effective rate per series — imitates skaters' "Bayesian ensemble over a large candidate population" without adding new leaf families.
+- Composes freely with `with_holt` / `with_ar2` / `with_seasonal` — those still add their own opt-in leaves on top.
+
+### Benchmark: populations regressed on M5 retail
+
+Same pattern as Holt (alpha-3) and Yeo-Johnson (alpha-6) — the paper's design regresses on M5 retail specifics:
+
+| variant | MAE (median) | MAE (mean) | cover@90 | fit time |
+|---|---|---|---|---|
+| Laplace (plain, 3 leaves) | 5.46 | 7.05 | 0.961 | 0.24 s |
+| **Laplace + Populations (7 leaves)** | **5.58 (+2.2%)** | **7.55 (+7.1%)** | **0.966** | 0.47 s |
+| Laplace + AR2 + S7 (best config) | 5.09 | 6.64 | 0.970 | 0.38 s |
+| **Laplace + Populations + AR2 + S7** | **5.36 (+5.3%)** | **7.35 (+10.7%)** | **0.974** | 0.61 s |
+
+**Hypothesized cause.** The softmax weighting collapses onto a single best-fitting α per series based on cumulative log-lik. On M5's short training windows (~1900 obs, 28-day held-out), that collapse happens quickly and the wrong α often wins — the residual variance's dependence on level (the thing that would justify the fast-EMA family) isn't strongly stationary, so a globally-best α is a mirage. Ensemble diversity that would help on longer, more stationary series just adds noise here.
+
+Coverage moved slightly (~+0.5 pp, similar magnitude to alpha-5 calibration).
+
+**Ship recommendation.** Opt-in with the tradeoff documented — for non-retail panels (skaters' FRED-non-price target) the population weighting should recover the paper's advertised behavior. On M5-style retail data, prefer the alpha-2 3-leaf default with `AR(2) + seasonal` opt-ins.
+
+### Notes
+
+Alpha surface: additive behind the `distributional` feature. Default builds unchanged.
+
 ## [0.12.0-alpha.6] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.12.0-alpha.6"
+version = "0.12.0-alpha.7"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.6"
+version = "0.12.0-alpha.7"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.12.0-alpha.6"
+version = "0.12.0-alpha.7"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.12.0-alpha.6"
+anofox-forecast = "0.12.0-alpha.7"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.6"
+version = "0.12.0-alpha.7"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.12.0-alpha.6",
+  "version": "0.12.0-alpha.7",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/examples/skaters_m5_benchmark.rs
+++ b/examples/skaters_m5_benchmark.rs
@@ -122,8 +122,9 @@ fn main() {
 
     // Slot layout stable so the pairwise matrix and summary lines match:
     //   0=AutoETS, 1=AutoTheta, 2=Laplace, 3=Laplace+H, 4=Laplace+AR2,
-    //   5=Laplace+S7, 6=Laplace+AR2+S7, 7=+Cal, 8=+YJ, 9=+YJ+Cal.
-    const N_MODELS: usize = 10;
+    //   5=Laplace+S7, 6=Laplace+AR2+S7, 7=+Cal, 8=+YJ, 9=+YJ+Cal,
+    //   10=Laplace+Pops, 11=Laplace+Pops+AR2+S7.
+    const N_MODELS: usize = 12;
     let labels: [&str; N_MODELS] = [
         "AutoETS",
         "AutoTheta",
@@ -135,6 +136,8 @@ fn main() {
         "Laplace+AR2+S7+Cal",
         "Laplace+AR2+S7+YJ",
         "Laplace+AR2+S7+YJ+Cal",
+        "Laplace+Pops",
+        "Laplace+Pops+AR2+S7",
     ];
     let mut results: Vec<Vec<SeriesResult>> = (0..N_MODELS).map(|_| Vec::new()).collect();
     let mut characteristics: Vec<Characteristics> = Vec::new();
@@ -175,7 +178,7 @@ fn main() {
 
         #[cfg(feature = "distributional")]
         {
-            let cfgs: [(usize, LaplaceForecaster); 8] = [
+            let cfgs: [(usize, LaplaceForecaster); 10] = [
                 (2, LaplaceForecaster::new()),
                 (3, LaplaceForecaster::new().with_holt_defaults()),
                 (4, LaplaceForecaster::new().with_ar2_defaults()),
@@ -207,6 +210,14 @@ fn main() {
                         .with_seasonal(7)
                         .with_yeo_johnson_mle()
                         .with_calibration(),
+                ),
+                (10, LaplaceForecaster::new().with_populations()),
+                (
+                    11,
+                    LaplaceForecaster::new()
+                        .with_populations()
+                        .with_ar2_defaults()
+                        .with_seasonal(7),
                 ),
             ];
             for (slot, model) in cfgs {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.12.0-alpha.6",
+  "version": "0.12.0-alpha.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -105,6 +105,12 @@ pub struct LaplaceForecaster {
     /// If true, fit the Yeo-Johnson λ via MLE at the start of `fit()` and
     /// store it in `fitted_yj_lambda`.
     yj_auto: bool,
+    /// If true, [`Self::init_leaves`] replaces the 3-leaf default with an
+    /// expanded 7-leaf population — EMA at 3 rates, drift at 2, AR(1)
+    /// mean-EMA at 2. The likelihood weighting picks the effective rate
+    /// per series, imitating skaters' "Bayesian ensemble over a large
+    /// candidate population" without adding new leaf families.
+    use_populations: bool,
 
     leaves: Vec<Box<dyn Leaf + Send>>,
     cum_log_liks: Vec<f64>,
@@ -155,6 +161,7 @@ impl LaplaceForecaster {
             calibrate: false,
             yj_lambda: None,
             yj_auto: false,
+            use_populations: false,
             leaves: Vec::new(),
             cum_log_liks: Vec::new(),
             n_obs: 0,
@@ -187,6 +194,23 @@ impl LaplaceForecaster {
     pub fn with_yeo_johnson_mle(mut self) -> Self {
         self.yj_auto = true;
         self.yj_lambda = None;
+        self
+    }
+
+    /// Replace the 3-leaf default set (one EMA / drift / AR(1) each) with
+    /// an expanded 7-leaf population that hyperparameter-sweeps the same
+    /// families:
+    ///
+    /// * `EMA` at α ∈ {0.05, 0.2, 0.5} (slow / medium / fast level tracking)
+    /// * `Drift` at α ∈ {0.05, 0.15}
+    /// * `AR(1)` mean-EMA at α ∈ {0.05, 0.15}
+    ///
+    /// The softmax-over-cumulative-log-lik weighting picks the effective
+    /// rate per series. Composes freely with `with_holt` / `with_ar2` /
+    /// `with_seasonal` — those still add their own opt-in leaves on top.
+    /// Adds compute proportional to the leaf count (roughly 2.3×).
+    pub fn with_populations(mut self) -> Self {
+        self.use_populations = true;
         self
     }
 
@@ -256,11 +280,23 @@ impl LaplaceForecaster {
     }
 
     fn init_leaves(&mut self) {
-        let mut leaves: Vec<Box<dyn Leaf + Send>> = vec![
-            Box::new(EmaLeaf::new(self.ema_alpha)),
-            Box::new(DriftLeaf::new(self.drift_alpha)),
-            Box::new(Ar1Leaf::new(self.ar_alpha_mean)),
-        ];
+        let mut leaves: Vec<Box<dyn Leaf + Send>> = if self.use_populations {
+            vec![
+                Box::new(EmaLeaf::new(0.05)),
+                Box::new(EmaLeaf::new(0.20)),
+                Box::new(EmaLeaf::new(0.50)),
+                Box::new(DriftLeaf::new(0.05)),
+                Box::new(DriftLeaf::new(0.15)),
+                Box::new(Ar1Leaf::new(0.05)),
+                Box::new(Ar1Leaf::new(0.15)),
+            ]
+        } else {
+            vec![
+                Box::new(EmaLeaf::new(self.ema_alpha)),
+                Box::new(DriftLeaf::new(self.drift_alpha)),
+                Box::new(Ar1Leaf::new(self.ar_alpha_mean)),
+            ]
+        };
         if let Some((a, b, phi)) = self.holt {
             leaves.push(Box::new(HoltLeaf::new(a, b, phi)));
         }
@@ -752,6 +788,45 @@ mod tests {
         let mut f = LaplaceForecaster::new().with_yeo_johnson(0.5);
         f.fit(&ts).unwrap();
         assert_eq!(f.yeo_johnson_lambda(), Some(0.5));
+    }
+
+    #[test]
+    fn with_populations_expands_leaf_count() {
+        let ts = ts_ar1(120, 0.4);
+        let mut f = LaplaceForecaster::new().with_populations();
+        f.fit(&ts).unwrap();
+        match Inspectable::explanation(&f).unwrap() {
+            Explanation::Laplace(e) => {
+                assert_eq!(e.leaf_names.len(), 7, "population set: {:?}", e.leaf_names);
+                // Rate labels are the same as the singleton versions —
+                // three EMAs, two Drifts, two AR(1)s.
+                let counts = |name: &str| -> usize {
+                    e.leaf_names.iter().filter(|n| n.as_str() == name).count()
+                };
+                assert_eq!(counts("ema"), 3);
+                assert_eq!(counts("drift"), 2);
+                assert_eq!(counts("ar1"), 2);
+                assert!((e.leaf_weights.iter().sum::<f64>() - 1.0).abs() < 1e-9);
+            }
+            other => panic!("expected Explanation::Laplace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn with_populations_composes_with_seasonal_and_ar2() {
+        let ts = ts_ar1(120, 0.4);
+        let mut f = LaplaceForecaster::new()
+            .with_populations()
+            .with_seasonal(7)
+            .with_ar2_defaults();
+        f.fit(&ts).unwrap();
+        match Inspectable::explanation(&f).unwrap() {
+            Explanation::Laplace(e) => {
+                // 7 population + 1 AR(2) + 1 seasonal = 9.
+                assert_eq!(e.leaf_names.len(), 9);
+            }
+            other => panic!("expected Explanation::Laplace, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Phase 3 of the roadmap. Stacked on #152 (alpha-6 YJ) — CI won't run until this retargets to main (see #151 for how stacked PRs failed here before). Will retarget after #152 lands.

## Summary

Adds `LaplaceForecaster::new().with_populations()` — replaces the 3-leaf default with a 7-leaf hyperparameter expansion in the same families:

- `EMA` at α ∈ {0.05, 0.20, 0.50} — slow / medium / fast level tracking
- `Drift` at α ∈ {0.05, 0.15}
- `AR(1)` mean-EMA at α ∈ {0.05, 0.15}

Softmax picks the effective rate per series. Imitates skaters' "Bayesian ensemble over a large candidate population" without adding new leaf families. Composes freely with `with_holt` / `with_ar2` / `with_seasonal`.

## Honest benchmark result: populations regressed on M5 retail

Same pattern as Holt (alpha-3) and Yeo-Johnson (alpha-6) — the paper's design regresses on M5 retail specifics:

| variant | MAE (median) | MAE (mean) | cover@90 | fit time |
|---|---|---|---|---|
| Laplace (plain, 3 leaves) | 5.46 | 7.05 | 0.961 | 0.24 s |
| **Laplace + Populations (7 leaves)** | **5.58 (+2.2%)** | **7.55 (+7.1%)** | **0.966** | 0.47 s |
| Laplace + AR2 + S7 (best config) | 5.09 | 6.64 | 0.970 | 0.38 s |
| **Laplace + Populations + AR2 + S7** | **5.36 (+5.3%)** | **7.35 (+10.7%)** | **0.974** | 0.61 s |

**Hypothesized cause.** Softmax weighting on short (~1900 obs) training windows collapses onto a single best-α per series based on cumulative log-lik. On M5 the residual variance's dependence on level isn't strongly stationary, so a globally-best α is a mirage. Ensemble diversity that would help on longer / more stationary series just adds noise.

Coverage moved ~+0.5 pp, similar magnitude to alpha-5 calibration.

## Ship recommendation

Opt-in with tradeoff documented — for non-retail panels (skaters' FRED-non-price target) the population weighting should recover the paper's advertised behavior. On M5-style retail, prefer the alpha-2 3-leaf default with `AR(2) + seasonal` opt-ins.

## Test plan

- [x] `cargo test --lib --features distributional laplace` → 36 passed (new: `with_populations_expands_leaf_count`, `with_populations_composes_with_seasonal_and_ar2`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --features distributional -- -D warnings` clean
- [x] `SAMPLE_SIZE=1000 cargo run --release --features distributional --example skaters_m5_benchmark` — numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)