### PR TITLE
Release v0.12.0-alpha.11: cross-panel M4 daily benchmark + AR(2) stationarity fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.11] - 2026-07-06
+
+### Added
+
+- **Cross-panel benchmark on M4 daily** — `examples/skaters_m4_daily_benchmark.rs`. Reads `validation/data/m4_daily_train.json` + `..._test.json`, runs the α-10 Laplace variants + `Laplace+auto` alongside `AutoETS` / `AutoTheta` on the 14-day competition horizon. Answers whether M5-optimized configs generalize (they don't cleanly — see finding below).
+
+### Fixed
+
+- **AR(2) leaf stationarity projection**. The prior version clamped `φ_1, φ_2` individually to `[-0.999, 0.999]` but let `φ_1 + φ_2` approach 1 on strongly-trending series (where the Yule-Walker MoM autocovariance estimates push the coefficients toward the unit-root boundary). The recursive h-step forecast then diverged exponentially: on the M4-daily benchmark, `Laplace+AR2` produced mean MAE = 787 (vs. 158 for plain Laplace) before the fix. Now the leaf projects `(φ_1, φ_2)` onto the AR(2) stationary triangle (`|φ_2| < 1`, `φ_1 + φ_2 < 1`, `φ_2 - φ_1 < 1`) with a 0.02 safety margin. Mean MAE for `Laplace+AR2` drops to 158.4 (matching plain Laplace) on M4 daily.
+- **Auto-selector trending guard**. `LaplaceForecaster::new().auto()` now checks `trend_strength` (R² of a linear fit `y ~ t`) before enabling AR(2) or fractional-diff. Trending series have inflated `|acf1|` (consecutive samples share the trend), which naively triggers those leaves — but their MoM estimators don't distinguish "trend" from "autocorrelation" cleanly. The guard skips them when `trend_strength > 0.5`.
+
+### Benchmark: cross-panel parity
+
+M4 daily (500 series, 14-day horizon) after fixes:
+
+| variant | MAE (median) | MAE (mean) | vs. AutoETS wr | cover@90 | fit |
+|---|---|---|---|---|---|
+| AutoTheta | 60.87 | 153.08 | 0.554 vs AutoETS | – | 28.8 s |
+| AutoETS | 61.92 | 154.72 | — | – | 40.2 s |
+| Laplace (plain) | 65.95 | 157.80 | 0.526 | 0.929 | 0.20 s |
+| **Laplace+auto** | 66.55 | 159.36 | **0.528** | 0.930 | 1.09 s |
+| Laplace+AR2+S7+FD+OU (M5 winner) | 67.47 | 164.21 | 0.516 | 0.930 | 1.68 s |
+
+**Cross-panel finding: no single fixed config wins both panels.** M5's hand-tuned kitchen sink loses to plain Laplace on M4 daily. But the α-10 auto-selector crosses **50% pairwise winrate vs. AutoETS on both** panels (50.8% on M5 α-9, 52.8% on M4 daily) — the per-series characteristic inspection generalizes where a fixed config doesn't.
+
+### Notes
+
+Alpha surface: additive. AR(2) fix is a behavior change (existing users get more conservative φ estimates and no more h-step blow-ups) — no API surface changed.
+
 ## [0.12.0-alpha.10] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.12.0-alpha.10"
+version = "0.12.0-alpha.11"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.10"
+version = "0.12.0-alpha.11"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.12.0-alpha.10"
+version = "0.12.0-alpha.11"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"
@@ -313,5 +313,10 @@ path = "examples/m5_ets_benchmark.rs"
 [[example]]
 name = "skaters_m5_benchmark"
 path = "examples/skaters_m5_benchmark.rs"
+required-features = ["distributional"]
+
+[[example]]
+name = "skaters_m4_daily_benchmark"
+path = "examples/skaters_m4_daily_benchmark.rs"
 required-features = ["distributional"]
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.12.0-alpha.10"
+anofox-forecast = "0.12.0-alpha.11"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.10"
+version = "0.12.0-alpha.11"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.12.0-alpha.10",
+  "version": "0.12.0-alpha.11",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/examples/skaters_m4_daily_benchmark.rs
+++ b/examples/skaters_m4_daily_benchmark.rs
@@ -1,0 +1,351 @@
+//! Cross-panel benchmark on M4 daily.
+//!
+//! Same design as `examples/skaters_m5_benchmark.rs`, retargeted to the
+//! M4 daily competition subset. Answers the cross-panel generalization
+//! question: does the M5-optimized best config (`Laplace + AR2 + S7 +
+//! FD + OU`) generalize to a different panel type?
+//!
+//! M4 daily is 4,227 non-price economic-adjacent series with a 14-day
+//! held-out competition horizon. Weekly seasonality is present but
+//! weaker than M5 retail. Series are longer (median ~2,900 obs vs. M5's
+//! ~1,900).
+//!
+//! Run: cargo run --release --features distributional --example skaters_m4_daily_benchmark
+//! Configure: SAMPLE_SIZE=500 (default 100) for a larger run.
+
+use anofox_forecast::core::TimeSeries;
+use anofox_forecast::models::exponential::AutoETS;
+use anofox_forecast::models::theta::AutoTheta;
+use anofox_forecast::models::Forecaster;
+
+#[cfg(feature = "distributional")]
+use anofox_forecast::models::{DistributionalForecaster, LaplaceForecaster};
+
+use chrono::{Duration, TimeZone, Utc};
+use std::collections::HashMap;
+use std::fs;
+use std::time::Instant;
+
+const HORIZON: usize = 14;
+const MIN_LEN: usize = 200;
+
+struct SeriesResult {
+    mae: f64,
+    coverage90: Option<f64>,
+    logpdf_mean: Option<f64>,
+    fit_us: u128,
+}
+
+struct ModelSummary {
+    name: &'static str,
+    n_ok: usize,
+    mae_median: f64,
+    mae_mean: f64,
+    coverage90_mean: Option<f64>,
+    logpdf_mean: Option<f64>,
+    total_ms: u128,
+}
+
+fn main() {
+    let sample_size: usize = std::env::var("SAMPLE_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+
+    let train_json = fs::read_to_string("validation/data/m4_daily_train.json")
+        .expect("read m4_daily_train.json");
+    let test_json =
+        fs::read_to_string("validation/data/m4_daily_test.json").expect("read m4_daily_test.json");
+    let train: HashMap<String, Vec<f64>> =
+        serde_json::from_str(&train_json).expect("parse train JSON");
+    let test: HashMap<String, Vec<f64>> =
+        serde_json::from_str(&test_json).expect("parse test JSON");
+
+    eprintln!("Loaded {} training series", train.len());
+
+    // Sort ids for reproducibility, keep only sufficiently long series.
+    let mut ids: Vec<&String> = train.keys().collect();
+    ids.sort();
+    let ids: Vec<&String> = ids
+        .into_iter()
+        .filter(|id| {
+            train.get(*id).is_some_and(|v| v.len() >= MIN_LEN)
+                && test.get(*id).is_some_and(|v| v.len() >= HORIZON)
+        })
+        .take(sample_size)
+        .collect();
+    eprintln!("Running benchmark on {} series", ids.len());
+
+    let base_date = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
+
+    // Slot layout — mirror of the M5 benchmark's Laplace variants for
+    // easy cross-panel comparison.
+    const N_MODELS: usize = 8;
+    let labels: [&str; N_MODELS] = [
+        "AutoETS",
+        "AutoTheta",
+        "Laplace",
+        "Laplace+AR2",
+        "Laplace+S7",
+        "Laplace+AR2+S7",
+        "Laplace+AR2+S7+FD+OU",
+        "Laplace+auto",
+    ];
+    let mut results: Vec<Vec<SeriesResult>> = (0..N_MODELS).map(|_| Vec::new()).collect();
+
+    let global_start = Instant::now();
+
+    for (idx, id) in ids.iter().enumerate() {
+        if idx % 25 == 0 {
+            eprintln!("[{}/{}] {}", idx, ids.len(), id);
+        }
+        let train_values = train.get(*id).unwrap().clone();
+        let test_values = test.get(*id).unwrap();
+        if train_values.len() < MIN_LEN {
+            continue;
+        }
+
+        let stamps: Vec<_> = (0..train_values.len())
+            .map(|i| base_date + Duration::days(i as i64))
+            .collect();
+        let train_ts = match TimeSeries::univariate(stamps, train_values.clone()) {
+            Ok(ts) => ts,
+            Err(_) => continue,
+        };
+
+        if let Some(r) = run_point(&mut AutoETS::new(), &train_ts, test_values) {
+            results[0].push(r);
+        }
+        if let Some(r) = run_point(&mut AutoTheta::new(), &train_ts, test_values) {
+            results[1].push(r);
+        }
+
+        #[cfg(feature = "distributional")]
+        {
+            let cfgs: [(usize, LaplaceForecaster); 6] = [
+                (2, LaplaceForecaster::new()),
+                (3, LaplaceForecaster::new().with_ar2_defaults()),
+                (4, LaplaceForecaster::new().with_seasonal(7)),
+                (
+                    5,
+                    LaplaceForecaster::new()
+                        .with_ar2_defaults()
+                        .with_seasonal(7),
+                ),
+                (
+                    6,
+                    LaplaceForecaster::new()
+                        .with_ar2_defaults()
+                        .with_seasonal(7)
+                        .with_fractional_diff_defaults()
+                        .with_ou_defaults(),
+                ),
+                (7, LaplaceForecaster::new().auto()),
+            ];
+            for (slot, model) in cfgs {
+                if let Some(r) = run_laplace(model, &train_ts, test_values) {
+                    results[slot].push(r);
+                }
+            }
+        }
+    }
+
+    let total_wall = global_start.elapsed();
+    eprintln!(
+        "\nBenchmark done in {:.1}s (wall-clock)",
+        total_wall.as_secs_f64()
+    );
+
+    let summaries: Vec<ModelSummary> = labels
+        .iter()
+        .zip(results.iter())
+        .map(|(name, r)| summarize(*name, r))
+        .collect();
+    print_summary(&summaries);
+    print_pairwise(&labels, &results);
+}
+
+fn run_point<F: Forecaster>(
+    model: &mut F,
+    train: &TimeSeries,
+    test: &[f64],
+) -> Option<SeriesResult> {
+    let t0 = Instant::now();
+    if model.fit(train).is_err() {
+        return None;
+    }
+    let fit_us = t0.elapsed().as_micros();
+    let fc = model.predict(HORIZON).ok()?;
+    let point = fc.primary();
+    if point.len() != test.len() {
+        return None;
+    }
+    let mae = mae(point, test);
+    Some(SeriesResult {
+        mae,
+        coverage90: None,
+        logpdf_mean: None,
+        fit_us,
+    })
+}
+
+#[cfg(feature = "distributional")]
+fn run_laplace(
+    mut model: LaplaceForecaster,
+    train: &TimeSeries,
+    test: &[f64],
+) -> Option<SeriesResult> {
+    let t0 = Instant::now();
+    if model.fit(train).is_err() {
+        return None;
+    }
+    let fit_us = t0.elapsed().as_micros();
+    let mixtures = model.forecast_dist(HORIZON).ok()?;
+    if mixtures.len() != test.len() {
+        return None;
+    }
+    let point: Vec<f64> = mixtures.iter().map(|m| m.mean()).collect();
+    let mae = mae(&point, test);
+    let mut covered = 0usize;
+    let mut logpdfs = Vec::with_capacity(test.len());
+    for (m, &y) in mixtures.iter().zip(test.iter()) {
+        if y >= m.quantile(0.05) && y <= m.quantile(0.95) {
+            covered += 1;
+        }
+        let lp = m.logpdf(y);
+        if lp.is_finite() {
+            logpdfs.push(lp);
+        }
+    }
+    let coverage = covered as f64 / test.len() as f64;
+    let logpdf_mean = if logpdfs.is_empty() {
+        None
+    } else {
+        Some(logpdfs.iter().sum::<f64>() / logpdfs.len() as f64)
+    };
+    Some(SeriesResult {
+        mae,
+        coverage90: Some(coverage),
+        logpdf_mean,
+        fit_us,
+    })
+}
+
+fn mae(pred: &[f64], truth: &[f64]) -> f64 {
+    let s: f64 = pred
+        .iter()
+        .zip(truth.iter())
+        .map(|(p, t)| (p - t).abs())
+        .sum();
+    s / pred.len() as f64
+}
+
+fn median(xs: &mut [f64]) -> f64 {
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = xs.len();
+    if n == 0 {
+        f64::NAN
+    } else if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        0.5 * (xs[n / 2 - 1] + xs[n / 2])
+    }
+}
+
+fn summarize(name: &'static str, results: &[SeriesResult]) -> ModelSummary {
+    let n_ok = results.len();
+    let mut maes: Vec<f64> = results.iter().map(|r| r.mae).collect();
+    let mae_mean = if n_ok == 0 {
+        f64::NAN
+    } else {
+        maes.iter().sum::<f64>() / n_ok as f64
+    };
+    let mae_median = median(&mut maes);
+    let covs: Vec<f64> = results.iter().filter_map(|r| r.coverage90).collect();
+    let coverage90_mean = if covs.is_empty() {
+        None
+    } else {
+        Some(covs.iter().sum::<f64>() / covs.len() as f64)
+    };
+    let lps: Vec<f64> = results.iter().filter_map(|r| r.logpdf_mean).collect();
+    let logpdf_mean = if lps.is_empty() {
+        None
+    } else {
+        Some(lps.iter().sum::<f64>() / lps.len() as f64)
+    };
+    let total_ms: u128 = results.iter().map(|r| r.fit_us).sum::<u128>() / 1_000;
+    ModelSummary {
+        name,
+        n_ok,
+        mae_median,
+        mae_mean,
+        coverage90_mean,
+        logpdf_mean,
+        total_ms,
+    }
+}
+
+fn print_summary(summaries: &[ModelSummary]) {
+    println!("\n=== M4 daily cross-panel benchmark ===");
+    println!(
+        "{:<22}{:>8}{:>14}{:>14}{:>16}{:>14}{:>16}",
+        "model",
+        "n",
+        "MAE (median)",
+        "MAE (mean)",
+        "cover@90 (mean)",
+        "logpdf (avg)",
+        "fit time (s)"
+    );
+    for s in summaries {
+        let cov = s
+            .coverage90_mean
+            .map(|v| format!("{:.3}", v))
+            .unwrap_or_else(|| "-".to_string());
+        let lp = s
+            .logpdf_mean
+            .map(|v| format!("{:.3}", v))
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<22}{:>8}{:>14.4}{:>14.4}{:>16}{:>14}{:>16.2}",
+            s.name,
+            s.n_ok,
+            s.mae_median,
+            s.mae_mean,
+            cov,
+            lp,
+            s.total_ms as f64 / 1000.0
+        );
+    }
+}
+
+fn print_pairwise(labels: &[&str], results: &[Vec<SeriesResult>]) {
+    let n = results.iter().map(|r| r.len()).min().unwrap_or(0);
+    if n == 0 {
+        return;
+    }
+    let winrate = |a: &[SeriesResult], b: &[SeriesResult]| -> f64 {
+        let wins = (0..n).filter(|&i| a[i].mae < b[i].mae).count();
+        wins as f64 / n as f64
+    };
+    println!(
+        "\n=== Pairwise MAE win-rate on {} matched series (row beats column) ===",
+        n
+    );
+    print!("{:<22}", "");
+    for name in labels {
+        print!("{:>16}", name);
+    }
+    println!();
+    for (i, row_name) in labels.iter().enumerate() {
+        print!("{:<22}", row_name);
+        for (j, _) in labels.iter().enumerate() {
+            if i == j {
+                print!("{:>16}", "-");
+            } else {
+                print!("{:>16.3}", winrate(&results[i], &results[j]));
+            }
+        }
+        println!();
+    }
+}

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.12.0-alpha.10",
+  "version": "0.12.0-alpha.11",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -23,6 +23,12 @@ use super::ensemble::{blend_horizon, softmax};
 struct AutoChars {
     seasonality_strength: f64,
     acf1: f64,
+    /// R² of a linear fit `y ~ t`. High values (> ~0.5) indicate a
+    /// dominant trend — the auto-selector uses this to avoid enabling
+    /// AR(2) on trending series (its MoM estimator pushes `φ₁ + φ₂ → 1`
+    /// on strong trends, producing recursive h-step blow-ups even with
+    /// the leaf's stationarity projection).
+    trend_strength: f64,
 }
 
 /// Compute (seasonality_strength_R², |ACF(1)|) on the training window.
@@ -34,10 +40,32 @@ fn auto_characteristics(train: &[f64], period: usize) -> AutoChars {
         return AutoChars {
             seasonality_strength: 0.0,
             acf1: 0.0,
+            trend_strength: 0.0,
         };
     }
     let mean_y: f64 = train.iter().sum::<f64>() / n as f64;
     let ss_tot: f64 = train.iter().map(|y| (y - mean_y).powi(2)).sum();
+
+    // Trend strength: R² of the linear fit y ~ t.
+    let t_mean = (n - 1) as f64 / 2.0;
+    let (mut sum_ty, mut sum_tt) = (0.0, 0.0);
+    for (t, y) in train.iter().enumerate() {
+        let dt = t as f64 - t_mean;
+        sum_ty += dt * (y - mean_y);
+        sum_tt += dt * dt;
+    }
+    let slope = if sum_tt > 0.0 { sum_ty / sum_tt } else { 0.0 };
+    let intercept = mean_y - slope * t_mean;
+    let ss_res_trend: f64 = train
+        .iter()
+        .enumerate()
+        .map(|(t, y)| (y - (intercept + slope * t as f64)).powi(2))
+        .sum();
+    let trend_strength = if ss_tot > 0.0 {
+        (1.0 - ss_res_trend / ss_tot).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
 
     // Phase-mean seasonal fit R².
     let period = period.max(1);
@@ -77,6 +105,7 @@ fn auto_characteristics(train: &[f64], period: usize) -> AutoChars {
     AutoChars {
         seasonality_strength,
         acf1,
+        trend_strength,
     }
 }
 
@@ -495,20 +524,26 @@ impl Forecaster for LaplaceForecaster {
         }
 
         // Auto-selector: inspect series characteristics before initialising
-        // leaves and set the opt-in toggles from the α-8 slicing evidence.
+        // leaves and set the opt-in toggles from residual-slicing evidence.
         // User-configured toggles are respected — auto only adds.
         if self.use_auto {
             let chars = auto_characteristics(values, self.auto_seasonal_period);
             if self.ou.is_none() {
                 self.ou = Some(0.1);
             }
-            if chars.acf1 > 0.4 && self.ar2.is_none() {
+            // Trending-guard: on trending series, `acf1` is inflated because
+            // consecutive samples share the trend. Enabling AR(2) then pushes
+            // its MoM estimator toward the unit-root boundary, and the
+            // recursive h-step forecast diverges (M4-daily benchmark caught
+            // a catastrophic mean-MAE blow-up). Skip AR(2) when trend
+            // dominates.
+            if chars.acf1 > 0.4 && chars.trend_strength < 0.5 && self.ar2.is_none() {
                 self.ar2 = Some(0.1);
             }
             if chars.seasonality_strength > 0.15 && self.seasonal_period.is_none() {
                 self.seasonal_period = Some(self.auto_seasonal_period);
             }
-            if chars.acf1 > 0.5 && self.frac_diff.is_none() {
+            if chars.acf1 > 0.5 && chars.trend_strength < 0.5 && self.frac_diff.is_none() {
                 self.frac_diff = Some((0.4, 0.1, 0.1));
             }
         }

--- a/src/models/laplace/leaves/ar2.rs
+++ b/src/models/laplace/leaves/ar2.rs
@@ -83,10 +83,33 @@ impl Ar2Leaf {
         }
         let phi1 = g1 * (g0 - g2) / det;
         let phi2 = (g0 * g2 - g1 * g1) / det;
-        self.phi1 = phi1.clamp(-0.999, 0.999);
-        self.phi2 = phi2.clamp(-0.999, 0.999);
+        let (phi1, phi2) = project_to_stationary(phi1, phi2);
+        self.phi1 = phi1;
+        self.phi2 = phi2;
         true
     }
+}
+
+/// Project `(φ₁, φ₂)` onto the AR(2) stationary triangle with a small
+/// safety margin. The triangle is defined by
+/// `|φ₂| < 1`, `φ₁ + φ₂ < 1`, `φ₂ − φ₁ < 1`. Without this projection, a
+/// near-unit-root AR(2) (common on trending series where MoM autocovariance
+/// estimates push `φ₁ + φ₂ → 1`) produces recursive h-step forecasts that
+/// diverge exponentially — the M4 daily benchmark showed mean MAE of 787
+/// vs. 158 for plain Laplace when the projection was absent.
+fn project_to_stationary(phi1: f64, phi2: f64) -> (f64, f64) {
+    const MARGIN: f64 = 0.02;
+    let phi2 = phi2.clamp(-1.0 + MARGIN, 1.0 - MARGIN);
+    let mut phi1 = phi1;
+    let sum = phi1 + phi2;
+    if sum > 1.0 - MARGIN {
+        phi1 = 1.0 - MARGIN - phi2;
+    }
+    let diff = phi2 - phi1;
+    if diff > 1.0 - MARGIN {
+        phi1 = phi2 - (1.0 - MARGIN);
+    }
+    (phi1.clamp(-2.0 + MARGIN, 2.0 - MARGIN), phi2)
 }
 
 impl Leaf for Ar2Leaf {


### PR DESCRIPTION
Cross-panel evidence: auto crosses 50% winrate vs. AutoETS on BOTH M5 and M4 daily. Fixed AR(2) blowup on trending series. Full details in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)