### PR TITLE
Release v0.12.0-alpha.17: multiplicative seasonal + exog scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-alpha.17] - 2026-07-06
+
+### Added — multiplicative seasonality + exog scaffold
+
+- **`MultiplicativeSeasonalLeaf`** — tracks per-phase multipliers on a shared level (`level · factor[phase]`) rather than adding a phase mean. Retail seasonality is often proportional (peak week = 3× baseline, not baseline + 5); the additive `SeasonalEmaLeaf` misfits this on retail. Guarded against divide-by-zero when the level is near 0.
+- **`LaplaceForecaster::with_seasonal_multiplicative(period, α)`** builder + `.with_seasonal_multiplicative_defaults(period)` shortcut (default α = 0.15). Composes with the additive `with_seasonal(period)` — the mixture picks per series.
+- **`LaplaceForecaster::with_exog_preregression()`** — API scaffold. Reserves the surface for a follow-up implementation of OLS preregression on the `TimeSeries`'s calendar regressors. Currently causes `fit()` to return `Err`; use `RegressionForecaster` in the meantime.
+
+### Notes
+
+Alpha surface: additive behind the `distributional` feature. The exog scaffold intentionally errors so downstream code can compile against the API without accidentally shipping stub behavior.
+
 ## [0.12.0-alpha.16] - 2026-07-06
 
 ### Added — feature-based routing across model families

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.12.0-alpha.15"
+version = "0.12.0-alpha.16"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.15"
+version = "0.12.0-alpha.16"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.12.0-alpha.16"
+version = "0.12.0-alpha.17"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.12.0-alpha.16"
+anofox-forecast = "0.12.0-alpha.17"
 ```
 
 ### Optional Features

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.12.0-alpha.16"
+version = "0.12.0-alpha.17"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.12.0-alpha.16",
+  "version": "0.12.0-alpha.17",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.12.0-alpha.16",
+  "version": "0.12.0-alpha.17",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -163,8 +163,8 @@ fn yj_inverse_with_jac(y: f64, lambda: f64) -> (f64, f64) {
 }
 use super::leaf::Leaf;
 use super::leaves::{
-    Ar1Leaf, Ar2Leaf, DriftLeaf, EmaLeaf, FractionalDiffLeaf, HoltLeaf, IntermittentLeaf, OuLeaf,
-    SeasonalEmaLeaf, YjWrappedLeaf,
+    Ar1Leaf, Ar2Leaf, DriftLeaf, EmaLeaf, FractionalDiffLeaf, HoltLeaf, IntermittentLeaf,
+    MultiplicativeSeasonalLeaf, OuLeaf, SeasonalEmaLeaf, YjWrappedLeaf,
 };
 use super::DistributionalForecaster;
 
@@ -254,6 +254,12 @@ pub struct LaplaceForecaster {
     /// alone (so the 90% interval can still dip below zero — proper
     /// truncated-Gaussian output is deferred).
     non_negative: bool,
+    /// `(period, α)` for the multiplicative seasonal-EMA leaf. Complements
+    /// the additive `seasonal_period`; retail seasonality is often
+    /// proportional (peak week = 3× baseline).
+    seasonal_mult: Option<(usize, f64)>,
+    /// Scaffold flag — see [`Self::with_exog_preregression`].
+    exog_scaffold_declared: bool,
 
     leaves: Vec<Box<dyn Leaf + Send>>,
     cum_log_liks: Vec<f64>,
@@ -317,6 +323,8 @@ impl LaplaceForecaster {
             ou: None,
             intermittent: None,
             non_negative: false,
+            seasonal_mult: None,
+            exog_scaffold_declared: false,
             leaves: Vec::new(),
             cum_log_liks: Vec::new(),
             n_obs: 0,
@@ -401,6 +409,40 @@ impl LaplaceForecaster {
     /// truncated-Gaussian output is deferred.
     pub fn non_negative(mut self) -> Self {
         self.non_negative = true;
+        self
+    }
+
+    /// Add a **multiplicative** seasonal-EMA leaf with the caller-supplied
+    /// period. Tracks per-phase multipliers on a shared level (retail
+    /// seasonality is often proportional — peak week = 3× baseline, not
+    /// baseline + 5). Composes with the additive
+    /// [`Self::with_seasonal`] — mixture picks whichever fits the data
+    /// better per series. `period < 2` is a no-op.
+    pub fn with_seasonal_multiplicative(mut self, period: usize, alpha: f64) -> Self {
+        if period >= 2 {
+            self.seasonal_mult = Some((period, alpha));
+        }
+        self
+    }
+
+    /// Multiplicative seasonal-EMA with the default rate `α = 0.15`.
+    pub fn with_seasonal_multiplicative_defaults(self, period: usize) -> Self {
+        self.with_seasonal_multiplicative(period, 0.15)
+    }
+
+    /// **Scaffold — not yet implemented.** Declares intent to preregress
+    /// `y` on the [`TimeSeries`]'s calendar regressors via OLS, then feed
+    /// residuals to the leaves. At `predict_with_exog()` time the OLS
+    /// intercept + `β·X_future` would be added back to the leaf mixture.
+    ///
+    /// Calling this builder currently causes `fit()` to return `Err`. The
+    /// API is reserved so downstream code can compile against it; the
+    /// implementation is planned as a follow-up. Until then, callers that
+    /// need exog preregression should use [`RegressionForecaster`](crate::models::regression::RegressionForecaster)
+    /// with its residual-Ridge / dynamic backends, or preregress in
+    /// application code.
+    pub fn with_exog_preregression(mut self) -> Self {
+        self.exog_scaffold_declared = true;
         self
     }
 
@@ -612,6 +654,9 @@ impl LaplaceForecaster {
         for &p in &self.seasonal_periods_multi {
             leaves.push(Box::new(SeasonalEmaLeaf::new(p, self.seasonal_alpha)));
         }
+        if let Some((p, a)) = self.seasonal_mult {
+            leaves.push(Box::new(MultiplicativeSeasonalLeaf::new(p, a)));
+        }
         leaves
     }
 
@@ -658,6 +703,13 @@ impl Default for LaplaceForecaster {
 impl Forecaster for LaplaceForecaster {
     fn fit(&mut self, series: &TimeSeries) -> Result<()> {
         validate_series_complete(series)?;
+        if self.exog_scaffold_declared {
+            return Err(ForecastError::InvalidParameter(
+                "LaplaceForecaster::with_exog_preregression() is a reserved scaffold; \
+                 implementation is planned. Use RegressionForecaster in the meantime."
+                    .into(),
+            ));
+        }
         let values = series.primary_values();
         if values.is_empty() {
             return Err(ForecastError::InvalidParameter(

--- a/src/models/laplace/leaves/mod.rs
+++ b/src/models/laplace/leaves/mod.rs
@@ -9,6 +9,7 @@ mod holt;
 mod intermittent;
 mod ou;
 mod seasonal_ema;
+mod seasonal_mult;
 mod yj_wrapper;
 
 pub use ar::Ar1Leaf;
@@ -20,4 +21,5 @@ pub use holt::HoltLeaf;
 pub use intermittent::IntermittentLeaf;
 pub use ou::OuLeaf;
 pub use seasonal_ema::SeasonalEmaLeaf;
+pub use seasonal_mult::MultiplicativeSeasonalLeaf;
 pub use yj_wrapper::YjWrappedLeaf;

--- a/src/models/laplace/leaves/seasonal_mult.rs
+++ b/src/models/laplace/leaves/seasonal_mult.rs
@@ -1,0 +1,176 @@
+//! Multiplicative seasonal-EMA leaf.
+//!
+//! Retail seasonality is often proportional (peak week = 3× baseline,
+//! not baseline + 5). The additive [`SeasonalEmaLeaf`](super::SeasonalEmaLeaf)
+//! misfits this on retail. Here we track a per-phase *multiplier* on a
+//! shared level:
+//!
+//! * `level`: a running EMA of the deseasonalised series (`y / factor[phase]`)
+//! * `factor[phase]`: a running EMA of `y / level` for that phase
+//! * h-step forecast at phase `(now + h - 1) mod period`: `level · factor[phase]`
+//!
+//! Predictive std uses `σ · √h` on the residual against the multiplicative
+//! forecast — same convention as the other leaves.
+//!
+//! Small numerical guard: when `level` is near zero (e.g. cold start or an
+//! all-zeros run) the multiplier update is skipped for that step so the
+//! ratio doesn't blow up.
+
+use crate::models::laplace::dist::Gaussian;
+use crate::models::laplace::leaf::Leaf;
+
+const LEVEL_TOL: f64 = 1e-6;
+
+pub struct MultiplicativeSeasonalLeaf {
+    period: usize,
+    alpha: f64,
+    level: f64,
+    initialized_level: bool,
+    factor: Vec<f64>,
+    factor_seen: Vec<bool>,
+    phase_step: usize,
+    n: usize,
+    ss: f64,
+    mean_resid: f64,
+}
+
+impl MultiplicativeSeasonalLeaf {
+    pub fn new(period: usize, alpha: f64) -> Self {
+        let period = period.max(1);
+        Self {
+            period,
+            alpha: alpha.clamp(1e-3, 1.0 - 1e-3),
+            level: 0.0,
+            initialized_level: false,
+            factor: vec![1.0; period],
+            factor_seen: vec![false; period],
+            phase_step: 0,
+            n: 0,
+            ss: 0.0,
+            mean_resid: 0.0,
+        }
+    }
+
+    fn sigma(&self) -> f64 {
+        if self.n < 2 {
+            return 1.0;
+        }
+        (self.ss / (self.n as f64 - 1.0)).sqrt().max(1e-9)
+    }
+
+    fn factor_at(&self, phase: usize) -> f64 {
+        if self.factor_seen[phase] {
+            self.factor[phase]
+        } else {
+            1.0
+        }
+    }
+}
+
+impl Leaf for MultiplicativeSeasonalLeaf {
+    fn name(&self) -> &'static str {
+        "seasonal_mult"
+    }
+
+    fn predict(&self, horizon: usize) -> Vec<Gaussian> {
+        let level = if self.initialized_level {
+            self.level
+        } else {
+            0.0
+        };
+        let base = self.sigma();
+        (1..=horizon)
+            .map(|h| {
+                let phase = (self.phase_step + h - 1) % self.period;
+                let mean = level * self.factor_at(phase);
+                Gaussian::new(mean, base * (h as f64).sqrt())
+            })
+            .collect()
+    }
+
+    fn observe(&mut self, y: f64) {
+        let phase = self.phase_step;
+        let factor = self.factor_at(phase);
+        let predicted = if self.initialized_level {
+            self.level * factor
+        } else {
+            y
+        };
+        let resid = y - predicted;
+        self.n += 1;
+        let delta = resid - self.mean_resid;
+        self.mean_resid += delta / self.n as f64;
+        self.ss += delta * (resid - self.mean_resid);
+
+        // Update level on the deseasonalised value.
+        let de_seasonalised = if factor.abs() > LEVEL_TOL {
+            y / factor
+        } else {
+            y
+        };
+        if !self.initialized_level {
+            self.level = de_seasonalised;
+            self.initialized_level = true;
+        } else {
+            self.level = self.alpha * de_seasonalised + (1.0 - self.alpha) * self.level;
+        }
+
+        // Update the phase multiplier (guarded against small level).
+        if self.level.abs() > LEVEL_TOL {
+            let new_factor = y / self.level;
+            if self.factor_seen[phase] {
+                self.factor[phase] =
+                    self.alpha * new_factor + (1.0 - self.alpha) * self.factor[phase];
+            } else {
+                self.factor[phase] = new_factor;
+                self.factor_seen[phase] = true;
+            }
+        }
+
+        self.phase_step = (self.phase_step + 1) % self.period;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locks_onto_a_multiplicative_seasonal() {
+        let mut leaf = MultiplicativeSeasonalLeaf::new(3, 0.4);
+        // Series with baseline 10 and multipliers [0.5, 2.0, 1.5].
+        for _ in 0..200 {
+            for &m in &[0.5, 2.0, 1.5] {
+                leaf.observe(10.0 * m);
+            }
+        }
+        let preds = leaf.predict(3);
+        assert!(
+            (preds[0].mean - 5.0).abs() < 1.0,
+            "h=1 → {}, target 5.0",
+            preds[0].mean
+        );
+        assert!(
+            (preds[1].mean - 20.0).abs() < 2.0,
+            "h=2 → {}, target 20.0",
+            preds[1].mean
+        );
+        assert!(
+            (preds[2].mean - 15.0).abs() < 1.5,
+            "h=3 → {}, target 15.0",
+            preds[2].mean
+        );
+    }
+
+    #[test]
+    fn cold_start_produces_finite_predictions() {
+        let mut leaf = MultiplicativeSeasonalLeaf::new(4, 0.3);
+        leaf.observe(5.0);
+        leaf.observe(0.0);
+        let preds = leaf.predict(6);
+        for (h, p) in preds.iter().enumerate() {
+            assert!(p.mean.is_finite(), "h={}", h + 1);
+            assert!(p.std.is_finite() && p.std > 0.0, "h={}", h + 1);
+        }
+    }
+}


### PR DESCRIPTION
MultiplicativeSeasonalLeaf for retail proportional seasonality. Exog preregression API scaffold (returns Err at fit; reserves the surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)