### PR TITLE
Release v0.13.1 — CI-only patch to enable crates.io publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-07
+
+CI-only patch to unblock the `Publish to crates.io` workflow. **No code changes vs. 0.13.0** — same distributional shell, same benchmark numbers, same API surface.
+
+### Fixed
+
+- CI: added `RUSTSEC-2025-0141` (bincode 1.3 unmaintained) and `RUSTSEC-2026-0204` (crossbeam-utils invalid pointer dereference in `fmt::Pointer`) to the `deny.toml` `[advisories].ignore` list and to the `cargo audit --ignore` flags in `.github/workflows/ci.yml`.
+- Both advisories are transitive and non-actionable in our tree (bincode 1.x is our optional serde format; crossbeam-utils fix awaits upstream propagation via `rayon`/`faer`). Neither represents an actual attack vector against `anofox-forecast`.
+- With the gate unblocked, this release is the first published to crates.io since `0.12.0-alpha.19`.
+
 ## [0.13.0] - 2026-07-07
 
 Bundles the α-21 through α-31 alpha series into one stable release. Introduces the demand-forecasting distributional stack inspired by [`microprediction/skaters`](https://github.com/microprediction/skaters) plus AID-driven family selection from `anofox-regression`. See the alpha entries below for detailed per-alpha changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.13.0"
+anofox-forecast = "0.13.1"
 ```
 
 ### Optional Features
@@ -266,22 +266,22 @@ anofox-forecast = "0.13.0"
 ```toml
 [dependencies]
 # Distributional forecasting shell (LaplaceForecaster, SmartForecaster, HierarchicalLaplace)
-anofox-forecast = { version = "0.13.0", features = ["distributional"] }
+anofox-forecast = { version = "0.13.1", features = ["distributional"] }
 
 # Forecastability analysis (MI, GCMI, distance correlation, fingerprint)
-anofox-forecast = { version = "0.13.0", features = ["forecastability"] }
+anofox-forecast = { version = "0.13.1", features = ["forecastability"] }
 
 # Forecastability + parallel (60× faster with rayon)
-anofox-forecast = { version = "0.13.0", features = ["forecastability", "parallel"] }
+anofox-forecast = { version = "0.13.1", features = ["forecastability", "parallel"] }
 
 # Parallel AutoARIMA (4-8x speedup via rayon, opt-in for embedding contexts like DuckDB)
-anofox-forecast = { version = "0.13.0", features = ["parallel"] }
+anofox-forecast = { version = "0.13.1", features = ["parallel"] }
 
 # Model serialization (save/load to JSON)
-anofox-forecast = { version = "0.13.0", features = ["serde"] }
+anofox-forecast = { version = "0.13.1", features = ["serde"] }
 
 # Probabilistic postprocessing (conformal, IDR, QRA — enabled by default)
-anofox-forecast = { version = "0.13.0", default-features = false }  # to disable
+anofox-forecast = { version = "0.13.1", default-features = false }  # to disable
 ```
 
 | Feature | Default | Description |

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this is

A CI-only patch release. **No code changes vs. 0.13.0.**

## Why

The `Publish to crates.io` workflow was gated on `Security Audit` + `Dependency Checks`, which failed on 3 transitive advisories that #176 now allow-lists. Since `0.13.0`'s tag has already been consumed by the (skipped) release workflow, re-tagging `v0.13.0` doesn't re-fire it. Cutting `v0.13.1` gives us a fresh tag → fresh workflow trigger → actual crates.io publish.

## Changes

- Version bump 0.13.0 → 0.13.1 in `Cargo.toml`, `crates/anofox-forecast-js/{Cargo.toml,package.json}`, `js/package.json`, `README.md`.
- `CHANGELOG.md` entry describing the CI-gate rationale.

## What ships to crates.io

Bit-identical code to what git-tag `v0.13.0` points at, plus this version-string bump. Same distributional shell, same benchmark numbers, same public API.

## Verification

- 92 laplace tests pass locally.
- With #176 landed, Security Audit + Dependency Checks pass on this branch's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)