### PR TITLE
fix(publish): exclude bulky benchmark data from crate tarball

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,21 @@ license = "MIT"
 repository = "https://github.com/sipemu/anofox-forecast"
 keywords = ["time-series", "forecasting", "arima", "ets", "statistics"]
 categories = ["science", "mathematics"]
+# Exclude bulky files that only exist for local benchmarking / regression
+# fixtures. The crates.io tarball is capped at 10 MB; validation/data
+# alone is ~1.4 GB. Users who want to reproduce our benchmarks can
+# fetch the datasets themselves — instructions are in the top-of-file
+# doc comments of examples/fev_benchmark.rs, examples/m5_wape.rs,
+# examples/skaters_m5_full_auto.rs.
+exclude = [
+    "validation/data/**/*.tsf",
+    "validation/data/**/*.csv",
+    "validation/data/**/*.json",
+    "validation/data/**/*.parquet",
+    "tests/data/",
+    "docs/rendered/",
+    "target/",
+]
 
 [features]
 default = ["postprocess"]


### PR DESCRIPTION
## Problem

v0.13.1's `Publish to crates.io` job passed all gates (advisories, tests, coverage) but **crates.io rejected the upload**:

```
error: failed to publish anofox-forecast v0.13.1 to registry at https://crates.io
Caused by: the remote server responded with an error (status 413 Payload Too Large): max upload size is: 10485760
```

## Root cause

`validation/data/` contains ~1.4 GB of benchmark datasets committed for local reproducibility (M4 daily/monthly/quarterly, M5 full CSV, Chronos-benchmark .tsf files, tourism panels, etc.). Cargo's default package discovery includes these in the tarball unless explicitly excluded.

## Fix

Adds an `exclude` list to `[package]` in `Cargo.toml`:

```toml
exclude = [
    "validation/data/**/*.tsf",
    "validation/data/**/*.csv",
    "validation/data/**/*.json",
    "validation/data/**/*.parquet",
    "tests/data/",
    "docs/rendered/",
    "target/",
]
```

## Verification

```
$ cargo package --list --allow-dirty | wc -l
487  # was probably thousands before

$ ls -lah target/package/*.crate
-rw-r--r-- 1 simonm simonm 3.7M  ...  anofox-forecast-0.13.1.crate
```

**Well under the 10 MB cap.**

## Follow-up

Once merged, cut v0.13.2 (fresh tag → fresh release workflow) to actually publish to crates.io. The distributional-shell code and everything else remains bit-identical to v0.13.0 and v0.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)