### PR TITLE
Release v0.13.2 — CI-only patch, actually reaches crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-08
+
+Second CI-only patch, again with **no code changes vs. 0.13.0 / 0.13.1**. Same distributional shell, same benchmark numbers, same API surface.
+
+### Fixed
+
+- Package tarball no longer includes `validation/data/**/*.{tsf,csv,json,parquet}`, `tests/data/`, `docs/rendered/`, `target/`. Those directories held ~1.4 GB of benchmark datasets committed for local reproducibility. crates.io rejected 0.13.1 with a 413 Payload Too Large error (10 MB cap); this release finally uploads (~3.7 MB tarball).
+- Users who want to reproduce the benchmarks fetch datasets themselves; instructions are in the top-of-file doc comments of `examples/fev_benchmark.rs`, `examples/m5_wape.rs`, `examples/skaters_m5_full_auto.rs`.
+
 ## [0.13.1] - 2026-07-07
 
 CI-only patch to unblock the `Publish to crates.io` workflow. **No code changes vs. 0.13.0** — same distributional shell, same benchmark numbers, same API surface.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anofox-forecast = "0.13.1"
+anofox-forecast = "0.13.2"
 ```
 
 ### Optional Features
@@ -266,22 +266,22 @@ anofox-forecast = "0.13.1"
 ```toml
 [dependencies]
 # Distributional forecasting shell (LaplaceForecaster, SmartForecaster, HierarchicalLaplace)
-anofox-forecast = { version = "0.13.1", features = ["distributional"] }
+anofox-forecast = { version = "0.13.2", features = ["distributional"] }
 
 # Forecastability analysis (MI, GCMI, distance correlation, fingerprint)
-anofox-forecast = { version = "0.13.1", features = ["forecastability"] }
+anofox-forecast = { version = "0.13.2", features = ["forecastability"] }
 
 # Forecastability + parallel (60× faster with rayon)
-anofox-forecast = { version = "0.13.1", features = ["forecastability", "parallel"] }
+anofox-forecast = { version = "0.13.2", features = ["forecastability", "parallel"] }
 
 # Parallel AutoARIMA (4-8x speedup via rayon, opt-in for embedding contexts like DuckDB)
-anofox-forecast = { version = "0.13.1", features = ["parallel"] }
+anofox-forecast = { version = "0.13.2", features = ["parallel"] }
 
 # Model serialization (save/load to JSON)
-anofox-forecast = { version = "0.13.1", features = ["serde"] }
+anofox-forecast = { version = "0.13.2", features = ["serde"] }
 
 # Probabilistic postprocessing (conformal, IDR, QRA — enabled by default)
-anofox-forecast = { version = "0.13.1", default-features = false }  # to disable
+anofox-forecast = { version = "0.13.2", default-features = false }  # to disable
 ```
 
 | Feature | Default | Description |

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/crates/anofox-forecast-js/package.json
+++ b/crates/anofox-forecast-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anofox-forecast-js",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
   "license": "MIT",
   "repository": {

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this is

Second CI-only patch. **No code changes vs 0.13.0 / 0.13.1.**

## Why

v0.13.1's publish attempt got past the advisories gate (thanks to #176) but was rejected by crates.io with 413 Payload Too Large — our tarball was pulling in ~1.4 GB of benchmark data. #178 added an `exclude` list to `[package]` that drops the tarball to 3.7 MB. Cutting v0.13.2 gives us a fresh tag to fire the release workflow with the smaller tarball.

## Changes

- Version bump 0.13.1 → 0.13.2 across `Cargo.toml`, `crates/anofox-forecast-js/{Cargo.toml,package.json}`, `js/package.json`, `README.md`.
- `CHANGELOG.md` entry documenting the tarball-size fix.

## Verified locally

```
$ ls -lah target/package/*.crate
-rw-r--r-- ... 3.7M ... anofox-forecast-0.13.2.crate
```

Under crates.io's 10 MB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)