### PR TITLE
fix(ci): bump Node to 22 in npm workflow (unblocks releases)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run JavaScript tests
         working-directory: js
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Upgrade npm for OIDC support
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump `node-version` from '20' to '22' in `.github/workflows/npm.yml` (both `test-js` and `publish-npm` jobs).
- Bump `js/package.json` version from `0.13.2` to `0.14.0` (missed during main v0.14.0 release; npm workflow reads publish version from here).
- Bump `crates/anofox-forecast-js/Cargo.toml` version from `0.13.2` to `0.14.0` (wasm-pack packages this crate's version).

Unblocks the release-triggered npm publish flow.

## The Node bug

On 2026-07-09 npm@latest bumped to 12.0.0, which requires Node ≥ 22. The publish job pinned Node 20 and does `npm install -g npm@latest` for OIDC support → **EBADENGINE**, publish fails.

Failure captured on the v0.14.0 release run: https://github.com/sipemu/anofox-forecast/actions/runs/29005381824/job/86077077581

## Why bump Node instead of pin npm

Node 20 hit EOL in April 2026 — it'll bit-rot regardless. Node 22 is Active LTS through 2027.

## Publishing v0.14.0 to npm after merge

The workflow only fires on new release events + manual dispatch, so the crate is on crates.io but not yet on npm.

**Manual dispatch against `main` (after this PR merges):**
```
gh workflow run npm -f dry_run=false
```

Note: dispatching against the `v0.14.0` tag would use that tag's *workflow file*, which still has the Node 20 bug. Dispatching against `main` post-merge uses the fixed workflow, and the checkout will fetch the same v0.14.0 source code + these version bumps.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `gh workflow run npm -f dry_run=false` (workflow_dispatch against main)
- [ ] Verify `@sipemu/anofox-forecast@0.14.0` on npmjs.com

## Not in scope

`.github/workflows/ci.yml` also pins Node 20 for the WASM test step. It's not broken (doesn't do `npm install -g`), but same EOL issue applies. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)