### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-09
+
+Small feature release: fixes a reported "near-flat forecast on N=48 monthly data" issue via a new opt-in seasonal-batch-init builder, plus a CI infrastructure fix that had blocked the v0.14.0 npm publish.
+
+### Added
+
+- **`LaplaceForecaster::with_seasonal_batch_init()`** — opt-in builder that pre-fills seasonal-EMA and multiplicative-seasonal phase levels from the **last training cycle** so the leaf competes fairly on the first observation. Closes a softmax cold-start handicap where the seasonal leaf spent one full cycle producing fallback predictions and permanently lagged plain EMA/Drift in `cum_log_liks`, causing near-flat forecasts on short-history seasonal panels.
+  - `SeasonalEmaLeaf::from_batch(period, alpha, values)` — new public constructor exposing the last-cycle init directly.
+  - `MultiplicativeSeasonalLeaf::from_batch(period, alpha, values)` — same for the multiplicative variant.
+  - Runnable demo: `cargo run --release --features distributional --example monthly_48_seasonal_diagnostic`.
+- **Opt-in gate rationale**: unconditional batch init regressed trending-seasonal panels on the fev-27 measurement (`tourism_monthly` +15 % MASE, `m4_hourly` +4 %) because the batch-initialised additive seasonal-EMA leaf then displaces the multiplicative-seasonal leaf that fits trending × seasonal data better. Data-driven auto-gates were tried and either missed tourism-shape drift or caught too much. Clean opt-in is honest.
+
+### Fixed
+
+- **CI: npm workflow now uses Node 22** (`.github/workflows/npm.yml`). The publish job pinned Node 20 and did `npm install -g npm@latest` for OIDC support — on 2026-07-09 npm@latest bumped to 12.0.0 requiring Node ≥ 22, which broke the v0.14.0 release-triggered publish with `EBADENGINE`. Node 20 is also past LTS.
+- **JS package versions** (`js/package.json`, `crates/anofox-forecast-js/Cargo.toml`) were left at `0.13.2` during the v0.14.0 release. Bumped to `0.15.0` alongside the main crate.
+
+### Diagnostic verification (`examples/monthly_48_seasonal_diagnostic.rs`)
+
+On N=48 monthly (period=12) synthetic data, forecasting the next 12 months:
+
+| case | default MAE | with_seasonal_batch_init() MAE |
+| :--- | ---: | ---: |
+| STRONG seasonal, low noise | 2.184 | **0.072** (−97 %) |
+| MEDIUM seasonal, medium noise | 0.420 | 0.359 (−15 %) |
+| WEAK seasonal, high noise | 0.576 | 0.686 (+19 %, edge case) |
+| SEASONAL DOMINATES noise | 3.657 | **0.179** (−95 %) |
+
+Peak-trough amplitude capture on the STRONG case:
+- Truth swing: 6.0; default swing: 0.33 (5 %); **fix swing: 5.97 (100 %)** — with the seasonal leaf now winning the softmax, `forecast_dist(24)` cycles through the phase pattern correctly instead of collapsing to a straight line.
+
+Trade-off documented on variable-amplitude cases:
+- Growing amplitude: 83 % of truth swing captured (net win)
+- Shrinking amplitude / anomalous last cycle: fix overshoots swing by 60–100 % but MAE still improves in every regime tested
+
+Two alternative init strategies (per-phase median across cycles, weighted-recent 0.5/0.3/0.2 blend) were prototyped and rejected — both regressed the shrinking / anomalous cases 1.8–2.9× vs last-cycle without helping any other regime. The overshoot is a streaming-EWMA memory effect (α = 0.5 is not aggressive enough to fully forget older cycles in 4 obs per phase), not an init-strategy problem.
+
+### Fev-27 aggregate
+
+`.auto()` default MASE **5.9239** — **bit-exact match to v0.14.0 baseline**. All new behaviour is behind the opt-in flag.
+
+### Compatibility
+
+- Zero breaking API changes. The new builder is additive.
+- `.with_seasonal_batch_init()` is off by default; existing callers see no behavioural change.
+- Minor version bump per semver (new public API).
+
 ## [0.14.0] - 2026-07-09
 
 Adds a **streaming Mahalanobis anomaly-detection module** (line-by-line port of `microprediction/timemachines`'s `mahalanobis` head) and ships **default-enabled accuracy improvements** to `LaplaceForecaster::auto()` / `.skaters()` that close the fev-27 WQL gap to AutoTheta.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/utils/comparison.rs
+++ b/src/utils/comparison.rs
@@ -288,10 +288,7 @@ pub fn compare_models(
         }
         let fit_time_us = start.elapsed().as_micros() as u64;
 
-        let in_sample = match model.fitted_values() {
-            Some(fitted) => compute_in_sample(actual, fitted)?,
-            None => return None,
-        };
+        let in_sample = compute_in_sample(actual, model.fitted_values()?)?;
 
         let cv_metrics = if config.run_cv {
             run_cv_for_factory(factory.as_ref(), series, &config.cv_config)
@@ -372,10 +369,7 @@ pub fn compare_registry(
         }
         let fit_time_us = start.elapsed().as_micros() as u64;
 
-        let in_sample = match model.fitted_values() {
-            Some(fitted) => compute_in_sample(actual, fitted)?,
-            None => return None,
-        };
+        let in_sample = compute_in_sample(actual, model.fitted_values()?)?;
 
         let cv_metrics = if config.run_cv {
             let factory = || spec.create();


### PR DESCRIPTION
## Summary

- **New**: opt-in `LaplaceForecaster::with_seasonal_batch_init()` builder + `SeasonalEmaLeaf::from_batch` / `MultiplicativeSeasonalLeaf::from_batch` — closes the reported "near-flat forecast on N=48 monthly data" bug via last-cycle phase-level pre-fill.
- **Fixed** (already in main from PR #191): npm workflow Node 22 bump + JS package version bump.
- **Version**: 0.14.0 → 0.15.0 (minor bump per semver — new public API).

## Behind the fix

`SeasonalEmaLeaf` started with `phase_seen = [false; period]`. During the first `period` observations, all predictions fell back to `global_ema`, ignoring seasonal structure. Those observations' `logpdf` scores accumulated in `cum_log_liks` and permanently handicapped the seasonal leaf. Drift or Holt won the softmax, and `forecast_dist(h)` returned `level + h · slope` — a straight line.

The fix pre-fills `phase_level[k]` from the last training cycle so the leaf competes fairly on the first observation. Opt-in gated because unconditional enable regressed `tourism_monthly` +15 % MASE on fev-27 (batch-initialised additive seasonal-EMA displaces the multiplicative-seasonal leaf on trending × seasonal data).

## Fev-27 default `.auto()`: bit-exact match to v0.14.0 baseline

MASE **5.9239** unchanged from v0.14.0. All new behaviour is behind the opt-in flag.

## Diagnostic (N=48 monthly, period=12)

| case | default MAE | with_seasonal_batch_init() MAE |
| :--- | ---: | ---: |
| STRONG seasonal | 2.184 | **0.072** (−97 %) |
| MEDIUM | 0.420 | 0.359 (−15 %) |
| WEAK/noisy | 0.576 | 0.686 (+19 %, edge case) |
| SEASONAL DOMINATES noise | 3.657 | **0.179** (−95 %) |

At H = 24: default swings 9 % of truth (flat, as reported); fix swings 99 %.

## Full details

- `CHANGELOG.md` § 0.15.0
- Runnable diagnostic: `cargo run --release --features distributional --example monthly_48_seasonal_diagnostic`
- Trade-off documentation: two alternative init strategies (cycle-median, weighted-recent) were prototyped and rejected — both regressed shrinking / anomalous cases 1.8–2.9× vs last-cycle without helping any regime.

## Test plan

- [x] `cargo test --lib --features 'anomaly serde'` — 2874 pass locally
- [x] `cargo run --release --features distributional --example monthly_48_seasonal_diagnostic` — matches table above
- [x] `SAMPLE_PER=500 MODELS="Laplace+auto,Laplace+skaters" cargo run --release --features distributional --example fev_benchmark` — `.auto()` MASE 5.9239 (bit-exact)
- [ ] CI on this PR
- [ ] Post-merge: crates.io + npm publish workflows fire on GitHub Release

## Compatibility

Zero breaking changes. Everything additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)