### PR TITLE
fix(ci): pin npm to 11 (npm@12 sigstore bundle bug)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -90,8 +90,13 @@ jobs:
         run: |
           echo "Current npm version:"
           npm --version
-          echo "Upgrading npm to latest (need >= 11.5.1 for OIDC)..."
-          npm install -g npm@latest
+          # Pin to npm 11 explicitly. npm@latest = 12.0.0 as of
+          # 2026-07-09 ships without the `sigstore` module that
+          # `libnpmpublish` requires for `--provenance` — publishes
+          # crash with MODULE_NOT_FOUND. npm 11.5+ has full OIDC +
+          # provenance support and is what we need.
+          echo "Pinning npm to 11 (avoids npm@12 sigstore bundle bug)..."
+          npm install -g npm@11
           echo "New npm version:"
           npm --version
           node --version


### PR DESCRIPTION
## Summary

- Pin \`npm install -g npm@11\` in \`.github/workflows/npm.yml\` publish step.
- Replaces \`npm@latest\` which resolves to 12.0.0 today and is missing the \`sigstore\` module required by \`libnpmpublish/lib/provenance.js\`.

## The bug

The v0.15.0 release-triggered npm publish (which had the Node 22 fix from PR #191) failed on a **different** upstream bug:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error Require stack: libnpmpublish/lib/provenance.js
\`\`\`

npm@12.0.0 ships without the \`sigstore\` module that \`libnpmpublish\` requires for \`--provenance\` publishes. Any trusted-publisher OIDC + provenance flow crashes.

Failure captured on the v0.15.0 release: https://github.com/sipemu/anofox-forecast/actions/runs/29022061659/job/86132274506

## Why pin instead of workaround

- Comment on the workflow already states \"need >= 11.5.1 for OIDC\" — npm 11 gives us that.
- \`npm@11\` has both full OIDC support AND the sigstore bundle intact.
- Removing \`--provenance\` would lose supply-chain attestation.
- Waiting for npm 12.0.1 is not a release blocker; we can revisit once upstream fixes.

## After merge

Trigger the npm workflow manually against \`main\`:

\`\`\`
gh workflow run npm -f dry_run=false
\`\`\`

## Test plan

- [ ] CI on this PR
- [ ] After merge: workflow_dispatch to publish \`@sipemu/anofox-forecast@0.15.0\` to npm
- [ ] Verify on npmjs.com

## Context

- v0.15.0 crates.io publish: ✅ succeeded on the same release event
- v0.15.0 GitHub release: created
- v0.14.0 npm publish: originally failed EBADENGINE (Node 20), fixed by PR #191 (Node 22 bump). But that release event has no npm workflow_dispatch history for 0.14.0 — 0.14.0 is unavailable on npm and remains so.
- v0.15.0 npm: currently failing sigstore. This PR fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)