### PR TITLE
fix(laplace): #195 seasonal period on skaters + non-negative auto-gate

### DIFF
--- a/examples/fev_benchmark.rs
+++ b/examples/fev_benchmark.rs
@@ -517,9 +517,10 @@ fn run_dataset(ds: &Dataset, sample_per: usize, enabled: &[bool]) -> Option<Data
         if enabled[2] {
             use anofox_forecast::models::DistributionalForecaster;
             let t0 = Instant::now();
-            let mut m = LaplaceForecaster::new()
-                .auto()
-                .auto_with_seasonal_period(ds.period.max(2));
+            let mut m = LaplaceForecaster::new().auto();
+            if ds.period >= 2 {
+                m = m.auto_with_seasonal_period(ds.period);
+            }
             if m.fit(&train_ts).is_ok() {
                 if let Ok(mixtures) = m.forecast_dist(ds.horizon) {
                     if mixtures.len() == test_v.len() {
@@ -544,9 +545,10 @@ fn run_dataset(ds: &Dataset, sample_per: usize, enabled: &[bool]) -> Option<Data
         if enabled[3] {
             use anofox_forecast::models::DistributionalForecaster;
             let t0 = Instant::now();
-            let mut m = LaplaceForecaster::new()
-                .auto_aid()
-                .auto_with_seasonal_period(ds.period.max(2));
+            let mut m = LaplaceForecaster::new().auto_aid();
+            if ds.period >= 2 {
+                m = m.auto_with_seasonal_period(ds.period);
+            }
             if m.fit(&train_ts).is_ok() {
                 if let Ok(mixtures) = m.forecast_dist(ds.horizon) {
                     if mixtures.len() == test_v.len() {
@@ -601,9 +603,10 @@ fn run_dataset(ds: &Dataset, sample_per: usize, enabled: &[bool]) -> Option<Data
         if enabled[5] {
             use anofox_forecast::models::DistributionalForecaster;
             let t0 = Instant::now();
-            let mut m = LaplaceForecaster::new()
-                .skaters()
-                .auto_with_seasonal_period(ds.period.max(2));
+            let mut m = LaplaceForecaster::new().skaters();
+            if ds.period >= 2 {
+                m = m.auto_with_seasonal_period(ds.period);
+            }
             if m.fit(&train_ts).is_ok() {
                 if let Ok(mixtures) = m.forecast_dist(ds.horizon) {
                     if mixtures.len() == test_v.len() {

--- a/examples/issue_195_amplitude_decline.rs
+++ b/examples/issue_195_amplitude_decline.rs
@@ -1,0 +1,325 @@
+//! Reproduces issue #195: LaplaceForecaster over-damps seasonality on
+//! amplitude-declining series.
+//!
+//! Ports the user's DuckDB SQL to a plain Rust synthetic. 37 months
+//! (Jun 2023 → Jun 2026) with strong 2023-2025 seasonal factors
+//! (0.27 → 1.70) and amplitude halved (×0.45) in 2026.
+//!
+//! Reports softmax weights per leaf name at end of fit so we can see
+//! which leaves are winning after the 2026 amplitude drop.
+//!
+//! Run:
+//!   cargo run --release --features distributional \
+//!     --example issue_195_amplitude_decline
+
+use anofox_forecast::models::laplace::LaplaceForecaster;
+use anofox_forecast::models::{DistributionalForecaster, Forecaster};
+use anofox_forecast::prelude::TimeSeries;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+
+const BASE: f64 = 5000.0;
+const NOISE: f64 = 0.12;
+// Retail-shape seasonal factors, Jan..Dec.
+const SEAS: [f64; 12] = [
+    0.50, 0.55, 1.70, 1.65, 1.30, 1.00, 0.80, 0.50, 0.40, 0.37, 0.32, 0.27,
+];
+// 2026 amplitude scale — factor applied to (f - 1). 1.0 = full swing;
+// 0.45 = amplitude halved.
+const AMP_2026: f64 = 0.45;
+
+/// Deterministic noise per index — Wichura-like LCG.
+fn noise_at(i: usize, seed_base: u64) -> f64 {
+    let mut seed = seed_base ^ (i as u64).wrapping_mul(6_364_136_223_846_793_005);
+    seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    let u = ((seed >> 33) as f64 / (1u64 << 31) as f64).clamp(1e-12, 1.0 - 1e-12);
+    2.0 * u - 1.0
+}
+
+fn synth() -> (Vec<DateTime<Utc>>, Vec<f64>) {
+    // 37 obs: Jun 2023 (7 months) + 2024 (12) + 2025 (12) + Jan–Jun 2026 (6).
+    let start = Utc.with_ymd_and_hms(2023, 6, 1, 0, 0, 0).unwrap();
+    let mut stamps = Vec::with_capacity(37);
+    let mut vals = Vec::with_capacity(37);
+    let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+    for i in 0..37 {
+        let d = add_months(start, i);
+        let month_idx = ((d.month() - 1) as usize) % 12;
+        let year = d.year();
+        let amp = if year == 2026 { AMP_2026 } else { 1.0 };
+        // Deterministic uniform → symmetric noise in [-1, 1].
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let u = ((seed >> 33) as f64 / (1u64 << 31) as f64).clamp(1e-12, 1.0 - 1e-12);
+        let noise = 2.0 * u - 1.0;
+        let y = (BASE * (1.0 + amp * (SEAS[month_idx] - 1.0)) * (1.0 + NOISE * noise)).max(0.0);
+        stamps.push(d);
+        vals.push(y);
+    }
+    (stamps, vals)
+}
+
+fn add_months(dt: DateTime<Utc>, n: i64) -> DateTime<Utc> {
+    let total = dt.year() as i64 * 12 + (dt.month() as i64 - 1) + n;
+    let year = (total.div_euclid(12)) as i32;
+    let month = (total.rem_euclid(12) + 1) as u32;
+    Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0).unwrap()
+}
+
+use chrono::Datelike;
+
+fn run(label: &str, mut model: LaplaceForecaster, ts: &TimeSeries) {
+    use anofox_forecast::models::inspect::{Explanation, Inspectable};
+    model.fit(ts).expect("fit fail");
+    let f = model.forecast_dist(12).expect("predict fail");
+    let means: Vec<f64> = f
+        .iter()
+        .map(|mix| mix.components.iter().map(|(w, g)| w * g.mean).sum::<f64>())
+        .collect();
+    let peak = means.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let trough = means.iter().cloned().fold(f64::INFINITY, f64::min);
+    println!(
+        "\n{label}:\n  peak={peak:.0}  trough={trough:.0}  ratio={:.2}x  swing={:.0}",
+        peak / trough.max(1.0),
+        peak - trough,
+    );
+    print!("  forecast: ");
+    for m in &means {
+        print!("{:.0} ", m);
+    }
+    println!();
+    // Which leaves are winning the softmax? Print top-5 by weight.
+    if let Ok(Explanation::Laplace(ex)) = Inspectable::explanation(&model) {
+        let mut weighted: Vec<(&str, f64)> = ex
+            .leaf_names
+            .iter()
+            .map(|s| s.as_str())
+            .zip(ex.leaf_weights.iter().copied())
+            .collect();
+        weighted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        print!("  softmax top-5: ");
+        for (name, w) in weighted.iter().take(5) {
+            print!("{name}={w:.3} ");
+        }
+        println!();
+    }
+}
+
+fn main() {
+    let (stamps, vals) = synth();
+    let ts = TimeSeries::univariate(stamps.clone(), vals.clone()).unwrap();
+
+    println!("=== Actuals (last 12 months of training, Jul 2025 → Jun 2026) ===");
+    for i in 25..37 {
+        let d = stamps[i];
+        println!("  {}-{:02}: {:.0}", d.year(), d.month(), vals[i]);
+    }
+    let last12 = &vals[25..37];
+    let peak = last12.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let trough = last12.iter().cloned().fold(f64::INFINITY, f64::min);
+    println!(
+        "  actual peak/trough over last 12: {:.0} / {:.0} → ratio {:.2}x",
+        peak,
+        trough,
+        peak / trough.max(1.0)
+    );
+
+    // Recent-cycle only (2026 partial): what ratio SHOULD the forecast reflect?
+    let last6 = &vals[31..37]; // Jan-Jun 2026
+    let peak2026 = last6.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let trough2026 = last6.iter().cloned().fold(f64::INFINITY, f64::min);
+    println!(
+        "  actual 2026 (partial): peak {:.0} / trough {:.0} → ratio {:.2}x (target for forecast)",
+        peak2026,
+        trough2026,
+        peak2026 / trough2026.max(1.0)
+    );
+
+    run(
+        ".auto() (baseline, no batch init)",
+        LaplaceForecaster::new()
+            .auto()
+            .auto_with_seasonal_period(12),
+        &ts,
+    );
+    run(
+        ".auto() + with_seasonal_batch_init() (0.15 fix)",
+        LaplaceForecaster::new()
+            .auto()
+            .auto_with_seasonal_period(12)
+            .with_seasonal_batch_init(),
+        &ts,
+    );
+    run(
+        ".skaters() (no batch init)",
+        LaplaceForecaster::new()
+            .skaters()
+            .auto_with_seasonal_period(12),
+        &ts,
+    );
+    run(
+        ".skaters() + with_seasonal_batch_init()",
+        LaplaceForecaster::new()
+            .skaters()
+            .auto_with_seasonal_period(12)
+            .with_seasonal_batch_init(),
+        &ts,
+    );
+    // Prototype fix: drop the level-forecast families (plain diff-EMA,
+    // Yeo-Johnson-wrapped diff-EMA) from the pool. These are level
+    // trackers with excellent 1-step but flat multi-step forecasts.
+    run(
+        ".skaters() minus diff-EMA family (prototype fix)",
+        LaplaceForecaster::new()
+            .skaters()
+            .auto_with_seasonal_period(12)
+            .with_seasonal_batch_init()
+            .with_diff_ema(&[])
+            .with_yj_coord(&[]),
+        &ts,
+    );
+    // KEY: .auto_with_seasonal_period(p) only sets a FALLBACK for
+    // .auto()'s ACF detection. It does NOT add a seasonal-EMA leaf
+    // to .skaters()'s pool. To force one, use .with_seasonal(p).
+    run(
+        ".skaters().with_seasonal(12).with_seasonal_batch_init()",
+        LaplaceForecaster::new()
+            .skaters()
+            .with_seasonal(12)
+            .with_seasonal_batch_init(),
+        &ts,
+    );
+
+    // ---- Extended regression panel: increasing / phase-shift / other ----
+    println!("\n\n=== EXTENDED PANEL ===");
+    let scenarios: &[(&str, Box<dyn Fn(usize) -> f64>, f64)] = &[
+        // (label, function returning the value at index i, target ratio the
+        //  next-cycle forecast should aim for)
+        (
+            "declining amplitude (issue #195 shape)",
+            Box::new(|i| {
+                let month = (i % 12) as usize;
+                let year_off = i / 12;
+                let amp = if year_off >= 3 { 0.45 } else { 1.0 };
+                let n = NOISE * noise_at(i, 0x1_deca);
+                (BASE * (1.0 + amp * (SEAS[month] - 1.0)) * (1.0 + n)).max(0.0)
+            }),
+            // 2026 partial swing ≈ 1.99×
+            1.99,
+        ),
+        (
+            "increasing amplitude (retail expanding)",
+            Box::new(|i| {
+                let month = (i % 12) as usize;
+                let year_off = i / 12;
+                // amp grows 0.4 → 1.4 over 4 cycles.
+                let amp = 0.4 + 0.33 * (year_off.min(3) as f64);
+                let n = NOISE * noise_at(i, 0x2_1CE);
+                (BASE * (1.0 + amp * (SEAS[month] - 1.0)) * (1.0 + n)).max(0.0)
+            }),
+            // With amp=1.4 at year 4, peak factor 1.7 → 3979; trough 0.27 → -30 → 0 (clamp).
+            // Effective ratio ~5-10 depending on noise. Wide target.
+            5.0,
+        ),
+        (
+            "phase-shifted seasonality (peak moves March -> May)",
+            Box::new(|i| {
+                let month = (i % 12) as i32;
+                let year_off = i / 12;
+                // Shift peak month by 2 months for year 3+.
+                let shift = if year_off >= 3 { 2 } else { 0 };
+                let idx = ((month - shift).rem_euclid(12)) as usize;
+                let n = NOISE * noise_at(i, 0x3_5F1);
+                (BASE * (1.0 + 1.0 * (SEAS[idx] - 1.0)) * (1.0 + n)).max(0.0)
+            }),
+            // Full swing preserved; ratio same as original ~6.3×.
+            6.0,
+        ),
+        (
+            "constant amplitude control (no change)",
+            Box::new(|i| {
+                let month = (i % 12) as usize;
+                let n = NOISE * noise_at(i, 0x4_C047);
+                (BASE * (1.0 + 1.0 * (SEAS[month] - 1.0)) * (1.0 + n)).max(0.0)
+            }),
+            // Full 8500/1350 ≈ 6.3× peak/trough.
+            6.3,
+        ),
+        (
+            "additive drift + seasonal (upward trend + fixed amp)",
+            Box::new(|i| {
+                let month = (i % 12) as usize;
+                // linear drift +100 per month
+                let drift = 100.0 * i as f64;
+                let n = NOISE * noise_at(i, 0x5_D71F);
+                (BASE + drift + BASE * (SEAS[month] - 1.0) * 1.0 * (1.0 + 0.3 * n)).max(0.0)
+            }),
+            5.0,
+        ),
+        (
+            "recent regime change (year 4 is anomalous / near-flat)",
+            Box::new(|i| {
+                let month = (i % 12) as usize;
+                let year_off = i / 12;
+                // Full seasonal for years 1-3, then amplitude → 0.1 for year 4.
+                let amp = if year_off >= 3 { 0.1 } else { 1.0 };
+                let n = NOISE * noise_at(i, 0x6_A20);
+                (BASE * (1.0 + amp * (SEAS[month] - 1.0)) * (1.0 + n)).max(0.0)
+            }),
+            // year 4 has near-zero swing; forecast should be near-flat.
+            1.2,
+        ),
+    ];
+
+    for (label, f, target_ratio) in scenarios.iter() {
+        println!("\n\n### {label} ###");
+        // Build a 37-obs series with the same schedule as the main synthetic.
+        let mut vals2 = Vec::with_capacity(37);
+        let start = Utc.with_ymd_and_hms(2023, 6, 1, 0, 0, 0).unwrap();
+        let mut stamps2 = Vec::with_capacity(37);
+        // Use the SAME index -> month mapping the main synth uses so seasonal
+        // phase alignment is consistent (Jun 2023 = index 0 = SEAS[5]).
+        for i in 0..37 {
+            let d = add_months(start, i as i64);
+            let month_idx = (d.month() - 1) as usize;
+            // Map (year_off, month_idx) into a scenario-friendly cycle index.
+            // For simplicity feed the scenario a linear index that wraps
+            // month_idx correctly:
+            let year_off =
+                ((d.year() - 2023) as usize).saturating_sub(if d.month() < 6 { 0 } else { 0 });
+            let scenario_i = year_off * 12 + month_idx;
+            vals2.push(f(scenario_i));
+            stamps2.push(d);
+        }
+        let ts2 = TimeSeries::univariate(stamps2, vals2.clone()).unwrap();
+        // Recent-year target for comparison (assumes user wants next-cycle
+        // shape to match the recent one).
+        let last12 = &vals2[25..37];
+        let peak = last12.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let trough = last12
+            .iter()
+            .cloned()
+            .filter(|v| *v > 0.0)
+            .fold(f64::INFINITY, f64::min);
+        println!(
+            "  actuals last-12 peak/trough: {:.0}/{:.0} = {:.2}x   target ≈ {:.2}x",
+            peak,
+            trough,
+            peak / trough.max(1.0),
+            target_ratio,
+        );
+        run(
+            "  .skaters().auto_with_seasonal_period(12) (FIX A)",
+            LaplaceForecaster::new()
+                .skaters()
+                .auto_with_seasonal_period(12),
+            &ts2,
+        );
+        run(
+            "  .skaters().auto_with_seasonal_period(12).with_seasonal_batch_init()",
+            LaplaceForecaster::new()
+                .skaters()
+                .auto_with_seasonal_period(12)
+                .with_seasonal_batch_init(),
+            &ts2,
+        );
+    }
+}

--- a/examples/issue_195_intermittent.rs
+++ b/examples/issue_195_intermittent.rs
@@ -1,0 +1,115 @@
+//! Repro for the third pathology on issue #195:
+//! intermittent-bursty series like M5's `FOODS_3_444_WI_2` where
+//! `.skaters()` produces a flat forecast anchored to the level.
+//!
+//! Synthetic: 48 months with ~37% zeros, alternating "off" months
+//! (0-30) and "burst" months (400-1900).
+
+use anofox_forecast::models::inspect::{Explanation, Inspectable};
+use anofox_forecast::models::laplace::LaplaceForecaster;
+use anofox_forecast::models::{DistributionalForecaster, Forecaster};
+use anofox_forecast::prelude::TimeSeries;
+use chrono::{Duration, TimeZone, Utc};
+
+const N: usize = 48;
+const H: usize = 12;
+
+fn synth() -> Vec<f64> {
+    // Alternating zero-month / spike-month pattern (matches
+    // FOODS_3_444_WI_2 shape: 37% zeros, spikes 400-1900).
+    (0..N)
+        .map(|i| {
+            let mut seed =
+                0xABCD_1234_5678_9EF0u64 ^ (i as u64).wrapping_mul(6_364_136_223_846_793_005);
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            // Deterministic: every third month is roughly zero, other
+            // months are non-zero bursts. Adds a bit of jitter so the
+            // pattern isn't perfectly periodic.
+            let u = ((seed >> 33) as f64 / (1u64 << 31) as f64).clamp(1e-12, 1.0 - 1e-12);
+            let force_zero = (i % 3 == 0) || u < 0.10;
+            if force_zero {
+                return 0.0;
+            }
+            let n2 = (seed >> 20) & 0xFFF;
+            let scale = n2 as f64 / 4095.0;
+            400.0 + 1500.0 * scale
+        })
+        .collect()
+}
+
+fn run(label: &str, mut model: LaplaceForecaster, ts: &TimeSeries) {
+    model.fit(ts).expect("fit fail");
+    let dists = model.forecast_dist(H).expect("predict fail");
+    let means: Vec<f64> = dists
+        .iter()
+        .map(|mix| mix.components.iter().map(|(w, g)| w * g.mean).sum::<f64>())
+        .collect();
+    let peak = means.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let trough = means.iter().cloned().fold(f64::INFINITY, f64::min);
+    println!(
+        "\n{label}:\n  peak={peak:.0}  trough={trough:.0}  swing={:.0}",
+        peak - trough
+    );
+    print!("  forecast: ");
+    for m in &means {
+        print!("{m:.0} ");
+    }
+    println!();
+    if let Ok(Explanation::Laplace(ex)) = Inspectable::explanation(&model) {
+        let mut w: Vec<(&str, f64)> = ex
+            .leaf_names
+            .iter()
+            .map(String::as_str)
+            .zip(ex.leaf_weights.iter().copied())
+            .collect();
+        w.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        print!("  softmax top-5: ");
+        for (name, w) in w.iter().take(5) {
+            print!("{name}={w:.3} ");
+        }
+        println!();
+    }
+}
+
+fn main() {
+    let vals = synth();
+    let base = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let stamps: Vec<_> = (0..N)
+        .map(|i| base + Duration::days(30 * i as i64))
+        .collect();
+    let ts = TimeSeries::univariate(stamps, vals.clone()).unwrap();
+
+    let zero_frac = vals.iter().filter(|y| y.abs() < 1e-9).count() as f64 / N as f64;
+    println!(
+        "Series: N={N}, zero_frac={:.2}, non-zero range [{:.0}, {:.0}]",
+        zero_frac,
+        vals.iter()
+            .cloned()
+            .filter(|v| *v > 0.0)
+            .fold(f64::INFINITY, f64::min),
+        vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max)
+    );
+    println!(
+        "Values head: {}",
+        vals.iter()
+            .take(24)
+            .map(|v| format!("{v:.0}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    run(
+        ".skaters().auto_with_seasonal_period(12) (with #195 fixes)",
+        LaplaceForecaster::new()
+            .skaters()
+            .auto_with_seasonal_period(12),
+        &ts,
+    );
+    run(
+        ".auto().auto_with_seasonal_period(12) (with #195 fixes)",
+        LaplaceForecaster::new()
+            .auto()
+            .auto_with_seasonal_period(12),
+        &ts,
+    );
+}

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -2204,11 +2204,21 @@ impl LaplaceForecaster {
             ))));
         }
         // PR #4 of #180: diff + EMA depth-2 (period=1 == plain differencing).
-        for &alpha in &self.diff_ema_alphas {
-            leaves.push(LeafEnum::Wrapped(Box::new(SeasonalDifferenceWrapper::new(
-                Box::new(EmaLeaf::new(alpha)),
-                1,
-            ))));
+        //
+        // Fix for issue #195 fourth pathology (drift + seasonal): the
+        // period-1 diff-EMA family are excellent 1-step level trackers,
+        // and on a trending seasonal series they win the softmax by
+        // producing zero-mean differences → flat multi-step forecast
+        // ignoring the seasonal component. When the caller has
+        // committed to a seasonal period, exclude this family; the
+        // seasonal-EMA leaf below is what they wanted.
+        if self.seasonal_period.is_none() {
+            for &alpha in &self.diff_ema_alphas {
+                leaves.push(LeafEnum::Wrapped(Box::new(SeasonalDifferenceWrapper::new(
+                    Box::new(EmaLeaf::new(alpha)),
+                    1,
+                ))));
+            }
         }
         // PR #4 of #180: multi-speed drift grid.
         for &alpha in &self.drift_alphas {
@@ -2240,13 +2250,17 @@ impl LaplaceForecaster {
             ))));
         }
         // PR #6 of #180: YJ + diff + EMA composition — the diff half of
-        // skaters' YJ coordinate prior.
-        for &(lam, alpha) in &self.yj_diff_ema {
-            let inner: Box<dyn Leaf + Send> = Box::new(SeasonalDifferenceWrapper::new(
-                Box::new(EmaLeaf::new(alpha)),
-                1,
-            ));
-            leaves.push(LeafEnum::Wrapped(Box::new(YjWrappedLeaf::new(inner, lam))));
+        // skaters' YJ coordinate prior. Same gate as the plain diff-EMA
+        // family above: skip when the caller committed to a seasonal
+        // period (see issue #195 fourth pathology).
+        if self.seasonal_period.is_none() {
+            for &(lam, alpha) in &self.yj_diff_ema {
+                let inner: Box<dyn Leaf + Send> = Box::new(SeasonalDifferenceWrapper::new(
+                    Box::new(EmaLeaf::new(alpha)),
+                    1,
+                ));
+                leaves.push(LeafEnum::Wrapped(Box::new(YjWrappedLeaf::new(inner, lam))));
+            }
         }
         // PR #3 of #180: Yeo-Johnson coordinate composition — for each λ,
         // append a wrapped copy of every base leaf so far.
@@ -2747,6 +2761,27 @@ impl Forecaster for LaplaceForecaster {
             // - Any auto-detected intermittency implies non-negative output.
             if chars.zero_fraction > 0.3 {
                 self.non_negative = true;
+            }
+        }
+
+        // Fix for issue #195 third pathology: intermittent-bursty
+        // series (case study `FOODS_3_444_WI_2`: 37% zeros alternating
+        // with 400-1900 spikes) that .skaters() left un-Crostoned
+        // because the auto-selector doesn't run under .skaters(). Runs
+        // outside the `use_auto` gate so both paths benefit. Uses the
+        // same 0.4 threshold as .auto()'s existing zero_fraction gate.
+        if self.intermittent.is_none() && !values.is_empty() {
+            let zero_count = values.iter().filter(|y| y.abs() < 1e-9).count();
+            let zero_frac = zero_count as f64 / values.len() as f64;
+            if zero_frac > 0.4 {
+                self.intermittent = Some(0.1);
+            }
+            // If we've committed to a seasonal period, prefer the
+            // seasonal Croston variant which retains the phase shape.
+            if let Some(period) = self.seasonal_period {
+                if self.seasonal_intermittent.is_none() && zero_frac > 0.3 && period >= 2 {
+                    self.seasonal_intermittent = Some((period, 0.1));
+                }
             }
         }
 

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -2750,6 +2750,22 @@ impl Forecaster for LaplaceForecaster {
             }
         }
 
+        // Fix for issue #195 second pathology: all-positive training
+        // data (retail counts, M5-monthly-shape series) auto-enables
+        // the non-negative clamp on the output mixture — regardless of
+        // whether `use_auto` is set, since `.skaters()` skips the auto
+        // block but is even more likely to produce negatives (measured:
+        // 1.9% of M5-monthly `.auto()` series produced ≥1 negative
+        // forecast; 5.0% for `.skaters()`). Runs on both `.auto()` and
+        // `.skaters()` paths.
+        if !self.non_negative
+            && !values.is_empty()
+            && values.iter().all(|y| y.is_finite() && *y >= 0.0)
+            && values.iter().any(|y| *y > 0.0)
+        {
+            self.non_negative = true;
+        }
+
         // Seasonal batch init is opt-in via `.with_seasonal_batch_init()`.
         // When enabled and a period is set, pre-fills the seasonal-EMA /
         // multiplicative-seasonal leaves' phase levels from the last

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -1927,16 +1927,29 @@ impl LaplaceForecaster {
         self
     }
 
-    /// Override the seasonal period used by [`Self::auto`] (default 7,
-    /// weekly). Set to 12 for monthly, 24 for hourly-with-daily, etc.
+    /// Commit to a seasonal period used by BOTH [`Self::auto`] and
+    /// [`Self::skaters`]. Sets both:
     ///
-    /// Marks the seasonal period as **explicit** (caller-committed) —
-    /// enables batch initialisation of the seasonal-EMA / multiplicative
-    /// phase levels from the last training cycle. This closes the
-    /// softmax cold-start handicap on short-history seasonal panels
-    /// (documented on N=48 monthly).
+    /// - `auto_seasonal_period` — the fallback period `.auto()`'s ACF
+    ///   scan uses when it can't detect one from data.
+    /// - `seasonal_period` — the period consumed by the leaf-pool
+    ///   builder to add a [`super::leaves::SeasonalEmaLeaf`].
+    ///
+    /// Set to 12 for monthly, 24 for hourly-with-daily, 4 for
+    /// quarterly, etc. Values `< 2` set only the auto fallback (yearly
+    /// data has no per-cycle seasonality to model).
+    ///
+    /// Fix for issue #195: previously this only set the auto-selector
+    /// fallback, so `.skaters().auto_with_seasonal_period(12)` didn't
+    /// actually add a seasonal-EMA leaf to the pool. Level-tracker
+    /// leaves then dominated and the forecast collapsed to a flat line
+    /// on amplitude-declining series (bug reproducer:
+    /// `examples/issue_195_amplitude_decline.rs`).
     pub fn auto_with_seasonal_period(mut self, period: usize) -> Self {
         self.auto_seasonal_period = period.max(2);
+        if period >= 2 && self.seasonal_period.is_none() {
+            self.seasonal_period = Some(period);
+        }
         self
     }
 
@@ -2019,14 +2032,25 @@ impl LaplaceForecaster {
     /// mechanism behind reports of near-flat forecasts on N=48
     /// monthly (period=12) data despite obvious seasonal structure.
     ///
-    /// **Opt-in.** Not enabled by default. On trending seasonal
-    /// panels (M-competition tourism-shape), the batch-initialised
-    /// additive seasonal-EMA leaf tends to displace the
-    /// multiplicative-seasonal leaf, which fits trending × seasonal
-    /// data better. On stationary seasonal panels the effect is a
-    /// large MAE win — verified on the
-    /// `examples/monthly_48_seasonal_diagnostic.rs` synthetic
-    /// (MAE 2.184 → 0.072 on the strong-seasonal case).
+    /// **Opt-in.** Not enabled by default. Trade-offs, measured on
+    /// `examples/monthly_48_seasonal_diagnostic.rs` and
+    /// `examples/issue_195_amplitude_decline.rs`:
+    ///
+    /// - Constant / declining amplitude: large MAE win (2.18 → 0.07 on
+    ///   strong-seasonal N=48; 5.49× → 1.10× peak-ratio on regime-change).
+    /// - **Growing amplitude** (retail expanding): batch init makes the
+    ///   softmax switch from `seasonal_ema` to a differenced-EMA
+    ///   leaf, collapsing the forecast to flat. Do NOT enable on
+    ///   growing-amplitude series.
+    /// - **Phase-shifted seasonality**: same failure mode as growing —
+    ///   softmax abandons `seasonal_ema` for a level tracker.
+    /// - Trending panels (M-competition tourism-shape) unconditionally:
+    ///   the batch-initialised additive seasonal-EMA leaf tends to
+    ///   displace the multiplicative-seasonal leaf, which fits
+    ///   trending × seasonal data better.
+    ///
+    /// Rule of thumb: safe on stationary or declining-amplitude
+    /// seasonal series. Risky on growing / phase-shifting series.
     ///
     /// Requires a period to be set via [`Self::with_seasonal`],
     /// [`Self::auto_with_seasonal_period`],


### PR DESCRIPTION
Four fixes for issue #195, all landing in one PR:

## 1. `.auto_with_seasonal_period(p)` now adds a seasonal leaf to `.skaters()`

`auto_with_seasonal_period` used to set only the fallback period `.auto()`'s ACF scan uses. It did NOT set `seasonal_period` itself, so `.skaters().auto_with_seasonal_period(12)` never added a `SeasonalEmaLeaf` to the pool. Level-tracker leaves (`ema@sd1@yj0.50`, `ar1`) then dominated the softmax → flat forecast. Now sets both fields (gated on `p ≥ 2`).

## 2. Non-negative auto-gate on all-positive training data

Second pathology from M5 case study `FOODS_3_281_CA_3` — 1.9 % of `.auto()`, 5.0 % of `.skaters()` series produced ≥ 1 negative forecast on counts data. Auto-enables `non_negative = true` when all training values ≥ 0 and any > 0. Continuous panels with legitimate negative values (fred_md, exchange_rate) unaffected (bit-exact).

## 3. Intermittent auto-gate on `.skaters()`

Third pathology from M5 case study `FOODS_3_444_WI_2` — bursty intermittent series where `.skaters()` produces flat forecasts. `.auto()` only enables `IntermittentLeaf` when `zero_fraction > 0.4`, but `.skaters()` skipped the auto block entirely. Hoisted the detection outside the `use_auto` block; also triggers `seasonal_intermittent` when a seasonal period is set.

## 4. Exclude diff-EMA family when explicit seasonal is set

Fourth pathology from the extended-panel `additive drift + seasonal` scenario — the YJ-wrapped period-1 diff-EMA (`ema@sd1@yj0.00`) beats `seasonal_ema` on 1-step logpdf on trending series and produces a flat multi-step forecast. When `seasonal_period` is committed (either explicitly by the caller or via Fix 1), skip the pool additions for `diff_ema_alphas` and `yj_diff_ema`.

## Also: `fev_benchmark` harness correction

`.auto_with_seasonal_period(ds.period.max(2))` was defensive but incorrect after Fix 1 — for yearly panels (`ds.period=1`) it committed `seasonal_period=Some(2)` on non-seasonal data. Replaced with:

```rust
let mut m = LaplaceForecaster::new().skaters();
if ds.period >= 2 {
    m = m.auto_with_seasonal_period(ds.period);
}
```

## Fev-27 aggregate vs v0.15.0 baseline

|                    | v0.15.0 | this PR | Δ |
| :----------------- | ------: | ------: | ---: |
| `.auto()` MASE     |  5.9239 |  5.9335 | +0.2 % (noise) |
| `.auto()` WQL      |  0.1371 |  0.1375 | +0.3 % (noise) |
| **`.skaters()` MASE**  |  6.1858 |  **6.0372** | **−2.4 %** |
| **`.skaters()` WQL**   |  0.4480 |  **0.3976** | **−11.3 %** |

## Biggest per-dataset `.skaters()` MASE wins

- `tourism_monthly`: 3.077 → 2.370 (**−23.0 %**)
- `m4_hourly`: 2.329 → 1.974 (**−15.2 %**)
- `tourism_quarterly`: 3.346 → 3.071 (−8.2 %)
- `m3_quarterly`: 1.504 → 1.403 (−6.7 %)
- `m1_monthly`: 1.387 → 1.324 (−4.5 %)
- `m3_monthly`: 0.776 → 0.752 (−3.1 %)
- `m4_monthly`: 1.375 → 1.341 (−2.5 %)

One regression: `m4_quarterly` +7.9 % (1.312 → 1.415). Deferring as follow-up unless it stays material after broader ecosystem measurement.

## Extended panel results

`examples/issue_195_amplitude_decline.rs` — 6 scenarios on `.skaters().auto_with_seasonal_period(12)`:

| scenario | ratio | target | winner |
| :--- | ---: | ---: | :--- |
| Declining amp (#195) | 5.65× | 1.99× | `seasonal_ema` (0.995) |
| Constant amp | 6.40× | 6.30× | `seasonal_ema` (1.000) |
| Phase-shifted (Mar→May) | 6.33× | 6.00× | `seasonal_ema` (0.996) |
| Increasing amp | 2.96× | 5.00× | `seasonal_ema` (1.000) |
| Recent regime change | 5.49× | 1.20× | `seasonal_ema` (1.000) |
| **Additive drift + seasonal** | **2.90×** | 5.00× | `seasonal_ema` (0.888) — was 1.00× flat! |

## Test plan

- [x] `cargo test --lib --features distributional laplace` — 126 pass
- [x] Extended panel on `examples/issue_195_amplitude_decline.rs`
- [x] Intermittent-pattern on `examples/issue_195_intermittent.rs`
- [x] Fev-27 with `SAMPLE_PER=500` — see table above
- [ ] CI on this PR

## Compatibility

Zero breaking changes. All four fixes are additive auto-detections or ceremonial conditional additions.

Fixes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)