### PR TITLE
Release v0.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Skaters-parity feature release. Ships four features from PR #202:

- fast_slow leaf family in `.skaters()` pool (default-on)
- `MultiScaleLaplace::forecast_dist` + `.with_scoring_horizon()` / `.with_scoring_window(w)` pass-through
- `LaplaceForecaster::with_parade(k)` for per-horizon PIT tracking
- `GpdTailsForecaster` for generalised Pareto tail splice

**Headline: MultiScaleLaplace + scH + scW=14 gives geomean MASE 1.4602 on the fev-27 leaderboard-comparable 23-dataset subset — −11.3 % vs v0.15.3 `.auto()`, biggest single-change improvement in project history.**

Moves this crate from ~rank 10 to ~rank 7-8 on the SOTA classical panel, competitive with Nixtla `auto_ets` (1.440).

## Test plan
- [x] `cargo test --release --features distributional --lib` — 3006/3006 pass
- [x] Version bumps: `Cargo.toml`, `crates/anofox-forecast-js/Cargo.toml`, `js/package.json`, `Cargo.lock`
- [x] CHANGELOG entry with full per-dataset breakdown (from PR #202)
- [x] SOTA_POSITIONING.md + README updated with new rank
- [x] New `.claude/skills/laplace-distributional.md` skill (user-invocable)
- [ ] Merge triggers GH release publish to crates.io + npm (per prior pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)