### PR TITLE
docs: M5 regression caveat for v0.15.4 winning recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documented
+
+- **M5 caveat for v0.15.4's winning recipe** — measured post-release on M5 200-series retail: `MultiScaleLaplace + scH + scW=14` **regresses vs plain `.skaters()`** by +8.7 % MASE / +9.5 % WAPE. The v0.15.4 wins are fev-27 (mixed classical) wins, not retail. Retail SKU / demand data still wants `.auto_aid()` or `SmartForecaster` (AID-selected count-distribution marginals). Documented in `docs/SOTA_POSITIONING.md` and README's rule-of-thumb table.
+
 ## [0.15.4] - 2026-07-14
 
 Skaters-parity feature release. Ports four modules from `microprediction/skaters` that were previously missing from our Laplace stack. The headline win is `MultiScaleLaplace` + v0.15.3's scoring knobs: **−11.3 % geomean MASE** on the leaderboard-comparable 23-dataset fev-27 subset (biggest single-change improvement in the project's history), moving this crate from ~rank 10 to ~rank 8 on the SOTA classical panel — competitive with Nixtla `auto_ets` (1.440), ahead of our own `AutoETS` (1.525) and `Seasonal Naive` (1.665).

--- a/README.md
+++ b/README.md
@@ -703,6 +703,8 @@ let dists = m.forecast_dist(H)?;               // Vec<GaussianMixture>
 
 Cost: 2-3× fit time vs plain `.skaters()` on longer panels (each activated scale runs a full skaters pool). Opt-in wrapper — not a default.
 
+> ⚠ **This recipe is a fev-27 (mixed-classical) win, not universal.** Measured on M5 200-series retail post-release: MultiScaleLaplace + scH + scW=14 **regresses vs plain `.skaters()`** by +8.7 % MASE / +9.5 % WAPE. Retail SKU / demand data still wants `.auto_aid()` or `SmartForecaster` (AID-selected count-distribution marginals) — see rules of thumb below.
+
 ### Where LaplaceForecaster shines — M5 full-30k retail
 
 | model | median MAE | fit time | vs. AutoETS |

--- a/docs/SOTA_POSITIONING.md
+++ b/docs/SOTA_POSITIONING.md
@@ -2,6 +2,25 @@
 
 *Updated 2026-07-14 for v0.15.4 (skaters-parity port: fast_slow + multiscale + parade + GPD tails). Datasets and metrics from autogluon/fev's Chronos-benchmark classical panel and our M5 200-series head-to-head. Reproducible via `cargo run --release --features distributional --example fev_benchmark` and `examples/m5_skaters_vs_autoets.rs`.*
 
+## ⚠ Read this first — different benchmarks want different recipes
+
+**The v0.15.4 winning recipe (`MultiScaleLaplace + scH + scW=14`) is a fev-27 win but REGRESSES on M5 retail.** Measured on M5 200-series:
+
+| Model | mean MASE | panel WAPE | fit time |
+|---|---:|---:|---:|
+| `Laplace + skaters()` | **0.9962** | **0.6868** | 0.8 s |
+| MultiScale + scH + scW=14 (v0.15.4 fev-27 winner) | 1.0833 (**+8.7 %**) | 0.7521 (**+9.5 %**) | 1.1 s |
+
+Selector by data type:
+
+| Data type | Recipe |
+|---|---|
+| **Continuous / M-competition / economic (fev-27-like)** | `MultiScaleLaplace::skaters(H).with_scoring_horizon().with_scoring_window(14)` |
+| **Retail SKU / demand / count data** | `LaplaceForecaster::new().auto_aid()` or `SmartForecaster::new()` (with `postprocess` feature) |
+| **Short-history (N < 100)** | `AutoTheta` / `AutoETS` from `crate::models::exponential` / `crate::models::theta` |
+
+Root cause of the M5 regression: M5 is intermittent count data where AID-selected Poisson / NegBin / Croston-family leaves are the right marginals — Gaussian mixtures aren't. MultiScaleLaplace wraps `.skaters()` (Gaussian pool), which is off the right selector for this data. **The two benchmark stories are structurally different tasks.**
+
 ## v0.15.4 headline — MultiScaleLaplace closes the gap to Nixtla classical
 
 The best config on the fev-27 leaderboard-comparable 23-dataset subset is now:


### PR DESCRIPTION
## Summary

Post-v0.15.4-release measurement: the winning fev-27 recipe (`MultiScaleLaplace + scoring_horizon + scoring_window=14`) **regresses on M5 retail** vs plain `.skaters()`.

## Measurement (M5 200-series, H=28, weekly-seasonality MASE)

| Model | mean MASE | panel WAPE | fit time |
|---|---:|---:|---:|
| `Laplace + skaters()` | **0.9962** | **0.6868** | 0.8 s |
| MultiScale + scH + scW=14 | 1.0833 (**+8.7 %**) | 0.7521 (**+9.5 %**) | 1.1 s |

## Why

M5 is intermittent daily count data. AID-selected Poisson / NegBin / Croston-family marginals fit these SKUs better than the Gaussian mixtures MultiScaleLaplace emits (it wraps `.skaters()`, a Gaussian pool). The v0.15.4 wins are fev-27 (mixed classical) wins, not universal.

## Doc changes

- **README.md** — warning box in the v0.15.4 recipe section
- **docs/SOTA_POSITIONING.md** — "Read this first" preamble with the M5 numbers + selector-by-data-type table
- **CHANGELOG.md** — `[Unreleased]` Documented entry

No code changes.

## Test plan
- [x] Docs only, no code
- [x] Measurement reproducible via `SAMPLE_SIZE=200 cargo run --release --features distributional --example m5_skaters_vs_autoets` (with the wrapper temporarily added to that example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)