### PR TITLE
Release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.5] - 2026-07-14
+
+Patch release to unblock the v0.15.4 crates.io publish, which was
+blocked by two `-D warnings` clippy errors in `src/models/laplace/gpd_tails.rs`:
+
+- Unused `ForecastError` import (only `Result` is used).
+- `fn gpd_sf` marked dead (no in-crate caller).
+
+### Fixed
+
+- **CI publish job** — dropped the unused `ForecastError` import; promoted `gpd_sf` and `gpd_isf` to `pub` (they belong on the `GpdTailsForecaster` public surface for users who want exceedance-survival / inverse-survival queries alongside the fitted `GpdTailParams`).
+
 ### Documented
 
-- **M5 caveat for v0.15.4's winning recipe** — measured post-release on M5 200-series retail: `MultiScaleLaplace + scH + scW=14` **regresses vs plain `.skaters()`** by +8.7 % MASE / +9.5 % WAPE. The v0.15.4 wins are fev-27 (mixed classical) wins, not retail. Retail SKU / demand data still wants `.auto_aid()` or `SmartForecaster` (AID-selected count-distribution marginals). Documented in `docs/SOTA_POSITIONING.md` and README's rule-of-thumb table.
+- **M5 caveat for v0.15.4's winning recipe** — measured post-v0.15.4-release on M5 200-series retail: `MultiScaleLaplace + scH + scW=14` **regresses vs plain `.skaters()`** by +8.7 % MASE / +9.5 % WAPE. The v0.15.4 wins are fev-27 (mixed classical) wins, not retail. Retail SKU / demand data still wants `.auto_aid()` or `SmartForecaster` (AID-selected count-distribution marginals). Documented in `docs/SOTA_POSITIONING.md` and README's rule-of-thumb table.
+
+### npm status
+
+npm publish for v0.15.4 succeeded (doesn't depend on clippy). This bumps npm to v0.15.5 in lockstep with the crate for consistency.
 
 ## [0.15.4] - 2026-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release to unblock the v0.15.4 crates.io publish. The v0.15.4 CI failed on clippy (`-D warnings`) which blocked `publish` — latest on crates.io is still v0.15.3. This bumps to v0.15.5 to trigger a fresh release workflow.

Includes:
- Clippy fix (PR #205) — unused `ForecastError` import + `gpd_sf`/`gpd_isf` promoted to `pub`
- Post-release doc caveat from PR #204 — M5 regression note

No behavior changes vs v0.15.4.

## Test plan
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] Version bumps: `Cargo.toml`, `crates/anofox-forecast-js/Cargo.toml`, `js/package.json`, `Cargo.lock`
- [x] CHANGELOG entry
- [ ] Merge → GH release triggers crates.io + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)