### PR TITLE
feat(laplace): skaters-parity v2 — fsum + prune + SplicedGaussianMixture + serde + robustness suite

### DIFF
--- a/src/models/laplace/dist.rs
+++ b/src/models/laplace/dist.rs
@@ -9,6 +9,30 @@
 use std::f64::consts::{PI, SQRT_2};
 
 const SQRT_2PI: f64 = 2.506_628_274_631_000_7;
+
+/// Neumaier-compensated sum. Bit-identical to CPython 3.12+'s built-in
+/// `sum()` on floats and to skaters' `mathx::fsum`. Reduces rounding
+/// error accumulation in mixture normalisation and weighted means; on
+/// long-tailed weighted sums (Gaussian mixtures with 20+ components)
+/// the plain `+=` accumulator can drift by a few ULPs, which cascades
+/// into mixture-quantile bisection differences.
+///
+/// Public so callers accumulating their own weighted sums (per-horizon
+/// blends, ensemble weights) can match the crate's numerical convention.
+pub fn fsum<I: IntoIterator<Item = f64>>(values: I) -> f64 {
+    let mut s = 0.0_f64;
+    let mut c = 0.0_f64;
+    for x in values {
+        let t = s + x;
+        if s.abs() >= x.abs() {
+            c += (s - t) + x;
+        } else {
+            c += (x - t) + s;
+        }
+        s = t;
+    }
+    s + c
+}
 /// Precomputed `0.5 · ln(2π)` — appears in `Gaussian::logpdf` and
 /// `GaussianMixture::logpdf`. Const so the compiler doesn't recompute
 /// via `(2·π).ln()` every call. `pub(super)` so the fit-loop can
@@ -78,13 +102,86 @@ impl GaussianMixture {
             .into_iter()
             .filter(|(w, _)| w.is_finite() && *w > 0.0)
             .collect();
-        let sum: f64 = kept.iter().map(|(w, _)| *w).sum();
+        // Neumaier-compensated normalisation. On 20-component mixtures
+        // the plain `+=` accumulator drifts ~2 ULPs, which cascades into
+        // downstream quantile-bisection differences. Matches skaters'
+        // `mathx::fsum` semantics.
+        let sum: f64 = fsum(kept.iter().map(|(w, _)| *w));
         if sum > 0.0 {
             for (w, _) in &mut kept {
                 *w /= sum;
             }
         }
         Self { components: kept }
+    }
+
+    /// Reduce component count by merging the closest-mean pair, weighting
+    /// by their masses, until `len <= max_components`. Mirrors skaters'
+    /// `Dist::prune` (ulp-tolerant pair selection over sorted components).
+    ///
+    /// Useful after a mixture-of-mixtures blend (e.g.
+    /// `MultiScaleLaplace::forecast_dist` concatenates each scale's
+    /// components with adjusted weights → the fine-horizon mixture can
+    /// have 50+ components). Pruning keeps quantile-bisection time
+    /// bounded without meaningfully changing the density.
+    pub fn prune(&self, max_components: usize) -> Self {
+        let max_components = max_components.max(1);
+        if self.components.len() <= max_components {
+            return self.clone();
+        }
+        // Stable sort by (mean, std, weight) — mirrors Python tuple sort.
+        let mut comps = self.components.clone();
+        comps.sort_by(|a, b| {
+            a.1.mean
+                .partial_cmp(&b.1.mean)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(
+                    a.1.std
+                        .partial_cmp(&b.1.std)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                )
+                .then(a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        });
+        let scale =
+            comps.first().unwrap().1.mean.abs() + comps.last().unwrap().1.mean.abs() + 1e-12;
+        while comps.len() > max_components {
+            // Best (smallest) inter-mean distance across all pairs.
+            let mut best_dist = f64::INFINITY;
+            for i in 0..comps.len() {
+                for j in (i + 1)..comps.len() {
+                    let d = (comps[i].1.mean - comps[j].1.mean).abs();
+                    if d < best_dist {
+                        best_dist = d;
+                    }
+                }
+            }
+            let thresh = best_dist + 1e-9 * scale;
+            let mut best_pair: Option<(usize, usize)> = None;
+            'outer: for i in 0..comps.len() {
+                for j in (i + 1)..comps.len() {
+                    if (comps[i].1.mean - comps[j].1.mean).abs() <= thresh {
+                        best_pair = Some((i, j));
+                        break 'outer;
+                    }
+                }
+            }
+            let (bi, bj) = best_pair.unwrap_or((0, 1));
+            let (wi, gi) = comps[bi];
+            let (wj, gj) = comps[bj];
+            let w_new = wi + wj;
+            let (m_new, s_new) = if w_new < 1e-300 {
+                (0.5 * (gi.mean + gj.mean), gi.std.max(gj.std).max(1e-12))
+            } else {
+                let m = (wi * gi.mean + wj * gj.mean) / w_new;
+                let v = (wi * (gi.variance() + (gi.mean - m).powi(2))
+                    + wj * (gj.variance() + (gj.mean - m).powi(2)))
+                    / w_new;
+                (m, v.max(0.0).sqrt())
+            };
+            comps[bi] = (w_new, Gaussian::new(m_new, s_new));
+            comps.remove(bj);
+        }
+        Self { components: comps }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -95,18 +192,19 @@ impl GaussianMixture {
         self.components.len()
     }
 
-    /// Mixture mean: `Σ w_i · μ_i`.
+    /// Mixture mean: `Σ w_i · μ_i`. Uses Neumaier-compensated summation.
     pub fn mean(&self) -> f64 {
-        self.components.iter().map(|(w, g)| w * g.mean).sum()
+        fsum(self.components.iter().map(|(w, g)| w * g.mean))
     }
 
-    /// Mixture variance: `Σ w_i (σ_i² + (μ_i − μ_mix)²)`.
+    /// Mixture variance: `Σ w_i (σ_i² + (μ_i − μ_mix)²)`. Neumaier-summed.
     pub fn variance(&self) -> f64 {
         let mu = self.mean();
-        self.components
-            .iter()
-            .map(|(w, g)| w * (g.variance() + (g.mean - mu).powi(2)))
-            .sum()
+        fsum(
+            self.components
+                .iter()
+                .map(|(w, g)| w * (g.variance() + (g.mean - mu).powi(2))),
+        )
     }
 
     pub fn std(&self) -> f64 {
@@ -208,6 +306,75 @@ fn inv_erf(x: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fsum_matches_naive_on_small_input() {
+        let xs = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let naive: f64 = xs.iter().sum();
+        let compensated = fsum(xs.iter().copied());
+        assert_eq!(naive, compensated);
+    }
+
+    #[test]
+    fn fsum_beats_naive_on_cancellation_stress() {
+        // Classic cancellation: 1e20, 1.0, -1e20 → naive gives 0, compensated gives 1.
+        let xs = [1e20, 1.0, -1e20];
+        let naive: f64 = xs.iter().sum();
+        let compensated = fsum(xs.iter().copied());
+        assert_eq!(naive, 0.0);
+        assert_eq!(compensated, 1.0);
+    }
+
+    #[test]
+    fn mixture_prune_reduces_component_count() {
+        let m = GaussianMixture::new(vec![
+            (0.1, Gaussian::new(0.0, 1.0)),
+            (0.1, Gaussian::new(0.05, 1.0)), // very close to previous
+            (0.1, Gaussian::new(1.0, 1.0)),
+            (0.1, Gaussian::new(1.02, 1.0)), // very close to previous
+            (0.1, Gaussian::new(2.0, 1.0)),
+            (0.5, Gaussian::new(5.0, 2.0)),
+        ]);
+        let pruned = m.prune(3);
+        assert!(pruned.len() <= 3);
+        // Mean should be preserved approximately (mixture mean is invariant
+        // under mean-preserving component merges, up to numerical error).
+        assert!((pruned.mean() - m.mean()).abs() < 0.1);
+    }
+
+    #[test]
+    fn mixture_prune_is_noop_when_under_cap() {
+        let m = GaussianMixture::new(vec![
+            (0.5, Gaussian::new(0.0, 1.0)),
+            (0.5, Gaussian::new(1.0, 1.0)),
+        ]);
+        let pruned = m.prune(20);
+        assert_eq!(pruned.len(), 2);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gaussian_serde_round_trip_is_bit_identical() {
+        let g = Gaussian::new(-3.141_592_653_589_793, 2.718_281_828_459_045);
+        let json = serde_json::to_string(&g).unwrap();
+        let round: Gaussian = serde_json::from_str(&json).unwrap();
+        assert_eq!(g.mean.to_bits(), round.mean.to_bits());
+        assert_eq!(g.std.to_bits(), round.std.to_bits());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gaussian_mixture_serde_round_trip_preserves_mean_and_std() {
+        let m = GaussianMixture::new(vec![
+            (0.4, Gaussian::new(-1.234, 0.5)),
+            (0.6, Gaussian::new(2.345, 1.5)),
+        ]);
+        let json = serde_json::to_string(&m).unwrap();
+        let round: GaussianMixture = serde_json::from_str(&json).unwrap();
+        assert_eq!(m.len(), round.len());
+        assert_eq!(m.mean().to_bits(), round.mean().to_bits());
+        assert_eq!(m.std().to_bits(), round.std().to_bits());
+    }
 
     #[test]
     fn standard_normal_pdf_cdf_quantile() {

--- a/src/models/laplace/gpd_tails.rs
+++ b/src/models/laplace/gpd_tails.rs
@@ -27,6 +27,7 @@ use crate::models::traits::Forecaster;
 /// z-thresholds; `zeta_*` are the empirical exceedance rates; `g_*` and
 /// `s_*` are the GPD shape and scale parameters (fitted by censored ML).
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GpdTailParams {
     pub t_lo: f64,
     pub t_up: f64,
@@ -237,6 +238,137 @@ pub fn spliced_quantile(mix: &GaussianMixture, params: &GpdTailParams, p: f64) -
     mix.quantile(ub)
 }
 
+/// A `GaussianMixture` body with GPD tails spliced in beyond frozen
+/// z-thresholds. Full port of skaters' `SplicedDist` — the body's own
+/// PIT through the standard normal defines the interior; GPD densities
+/// take over outside. Provides `cdf`, `pdf`, `logpdf`, `quantile`,
+/// numeric `mean`/`var`/`std`/`crps` (via a 65-node quantile grid).
+///
+/// Constructed by [`GpdTailsForecaster::spliced_mixtures`].
+pub struct SplicedGaussianMixture {
+    pub body: GaussianMixture,
+    pub params: GpdTailParams,
+    /// Cached 65-node quantile grid for moments / CRPS. Populated lazily.
+    grid: std::cell::OnceCell<Vec<f64>>,
+}
+
+impl SplicedGaussianMixture {
+    pub fn new(body: GaussianMixture, params: GpdTailParams) -> Self {
+        Self {
+            body,
+            params,
+            grid: std::cell::OnceCell::new(),
+        }
+    }
+
+    /// Push body-CDF through Φ⁻¹ to get the z-value used for the splice
+    /// region check.
+    fn z(&self, x: f64) -> f64 {
+        let u = self.body.cdf(x).clamp(1e-12, 1.0 - 1e-12);
+        phi_inv(u)
+    }
+
+    pub fn cdf(&self, x: f64) -> f64 {
+        let z = self.z(x);
+        let p = &self.params;
+        if z < p.t_lo {
+            p.zeta_lo * gpd_sf(p.t_lo - z, p.g_lo, p.s_lo)
+        } else if z > p.t_up {
+            1.0 - p.zeta_up * gpd_sf(z - p.t_up, p.g_up, p.s_up)
+        } else {
+            let c = p.interior_c();
+            p.zeta_lo + c * (phi(z) - phi(p.t_lo))
+        }
+    }
+
+    pub fn logpdf(&self, x: f64) -> f64 {
+        let base = self.body.logpdf(x);
+        if !base.is_finite() {
+            return base;
+        }
+        let z = self.z(x);
+        let p = &self.params;
+        // Standard-normal logpdf helper.
+        let phi_logpdf = |z: f64| -0.5 * z * z - 0.5 * (2.0 * PI).ln();
+        let corr = if z < p.t_lo {
+            p.zeta_lo.max(1e-300).ln() + gpd_logpdf(p.t_lo - z, p.g_lo, p.s_lo) - phi_logpdf(z)
+        } else if z > p.t_up {
+            p.zeta_up.max(1e-300).ln() + gpd_logpdf(z - p.t_up, p.g_up, p.s_up) - phi_logpdf(z)
+        } else {
+            p.interior_c().ln()
+        };
+        base + corr
+    }
+
+    pub fn pdf(&self, x: f64) -> f64 {
+        let lp = self.logpdf(x);
+        if lp < 700.0 {
+            lp.exp()
+        } else {
+            f64::INFINITY
+        }
+    }
+
+    pub fn quantile(&self, p: f64) -> f64 {
+        assert!((0.0..1.0).contains(&p) && p > 0.0);
+        spliced_quantile(&self.body, &self.params, p)
+    }
+
+    /// 65-node midpoint-rule quantile grid, cached. Feeds mean / var / crps.
+    fn qgrid(&self) -> &Vec<f64> {
+        self.grid.get_or_init(|| {
+            const N: usize = 65;
+            (0..N)
+                .map(|i| self.quantile((i as f64 + 0.5) / N as f64))
+                .collect()
+        })
+    }
+
+    pub fn mean(&self) -> f64 {
+        let q = self.qgrid();
+        q.iter().sum::<f64>() / q.len() as f64
+    }
+
+    pub fn var(&self) -> f64 {
+        let q = self.qgrid();
+        let m = self.mean();
+        q.iter().map(|x| (x - m).powi(2)).sum::<f64>() / q.len() as f64
+    }
+
+    pub fn std(&self) -> f64 {
+        self.var().sqrt()
+    }
+
+    /// CRPS via the quantile-representation midpoint rule. Same formula
+    /// as skaters' `SplicedDist.crps`: `E|X - x| - 0.5 · E|X - X'|`.
+    pub fn crps(&self, x: f64) -> f64 {
+        let q = self.qgrid();
+        let n = q.len();
+        let t1: f64 = q.iter().map(|v| (v - x).abs()).sum::<f64>() / n as f64;
+        let t2: f64 = 2.0
+            * q.iter()
+                .enumerate()
+                .map(|(i, v)| v * (2.0 * (i as f64 + 0.5) / n as f64 - 1.0))
+                .sum::<f64>()
+            / n as f64;
+        t1 - 0.5 * t2
+    }
+}
+
+/// GPD log-density, for [`SplicedGaussianMixture::logpdf`].
+fn gpd_logpdf(e: f64, gamma: f64, sigma: f64) -> f64 {
+    if gamma.abs() < 1e-9 {
+        return -sigma.ln() - e / sigma;
+    }
+    let arg = 1.0 + gamma * e / sigma;
+    if arg <= 0.0 {
+        return -745.0;
+    }
+    -sigma.ln() - (1.0 / gamma + 1.0) * arg.ln()
+}
+
+use std::f64::consts::PI;
+
 /// Wrapper: `LaplaceForecaster` + GPD-tail splice on top of the
 /// per-horizon mixture quantile. Implements `Forecaster` +
 /// `DistributionalForecaster` transparently; tails only affect quantile
@@ -279,6 +411,24 @@ impl GpdTailsForecaster {
     /// residual sample was too small to fit stable tails).
     pub fn tail_params(&self) -> Option<&GpdTailParams> {
         self.params.as_ref()
+    }
+
+    /// Return `Vec<SplicedGaussianMixture>` — the body per-horizon
+    /// mixtures with GPD tail splice applied. Prefers per-horizon
+    /// params (from `.with_parade(k)` on the inner) if fitted; falls
+    /// back to global params from 1-step residuals. Horizons without
+    /// any fitted tail params are omitted.
+    pub fn spliced_mixtures(&self, horizon: usize) -> Result<Vec<SplicedGaussianMixture>> {
+        let bodies = self.inner.forecast_dist(horizon)?;
+        Ok(bodies
+            .into_iter()
+            .enumerate()
+            .filter_map(|(h_idx, body)| {
+                let ph = self.per_horizon_params.get(h_idx).and_then(|o| *o);
+                let params = ph.or(self.params);
+                params.map(|p| SplicedGaussianMixture::new(body, p))
+            })
+            .collect())
     }
 
     /// Spliced quantile at fine horizon `h`, probability `p`. Uses
@@ -397,5 +547,67 @@ mod tests {
         let params = fit_gpd_tails(&z, 0.95).expect("fit failed");
         assert!(params.zeta_lo > 0.0 && params.zeta_up > 0.0);
         assert!(params.t_up > params.t_lo);
+    }
+
+    #[test]
+    fn spliced_mixture_round_trips_cdf_and_quantile() {
+        use super::super::dist::{Gaussian, GaussianMixture};
+        let body = GaussianMixture::new(vec![
+            (0.7, Gaussian::new(0.0, 1.0)),
+            (0.3, Gaussian::new(3.0, 0.5)),
+        ]);
+        let params = GpdTailParams {
+            t_lo: -2.0,
+            t_up: 2.0,
+            zeta_lo: 0.05,
+            zeta_up: 0.05,
+            g_lo: 0.1,
+            s_lo: 0.5,
+            g_up: 0.15,
+            s_up: 0.4,
+        };
+        let sp = SplicedGaussianMixture::new(body, params);
+        for &p in &[0.01, 0.1, 0.5, 0.9, 0.99] {
+            let q = sp.quantile(p);
+            assert!(q.is_finite(), "quantile({p}) = {q}");
+        }
+        // Mean / std / crps from qgrid — sanity, not exact.
+        let m = sp.mean();
+        let s = sp.std();
+        assert!(m.is_finite() && s.is_finite() && s > 0.0);
+        // logpdf integrates roughly to 1 (crude midpoint).
+        let mut total = 0.0;
+        for i in 0..201 {
+            let x = -10.0 + 20.0 * i as f64 / 200.0;
+            total += sp.pdf(x) * (20.0 / 200.0);
+        }
+        assert!((total - 1.0).abs() < 0.1, "pdf integral = {total}");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gpd_tail_params_serde_round_trip_is_bit_identical() {
+        let orig = GpdTailParams {
+            t_lo: -1.9599639845400545,
+            t_up: 1.9599639845400545,
+            zeta_lo: 0.024997500416604166,
+            zeta_up: 0.024997500416604166,
+            g_lo: 0.123456789012345,
+            s_lo: 0.987654321098765,
+            g_up: 0.234567890123456,
+            s_up: 0.876543210987654,
+        };
+        let json = serde_json::to_string(&orig).expect("ser");
+        let round: GpdTailParams = serde_json::from_str(&json).expect("de");
+        // Bit-exact — skaters caught a real float roundtrip divergence
+        // this way; we replicate the same gate.
+        assert_eq!(orig.t_lo.to_bits(), round.t_lo.to_bits());
+        assert_eq!(orig.t_up.to_bits(), round.t_up.to_bits());
+        assert_eq!(orig.zeta_lo.to_bits(), round.zeta_lo.to_bits());
+        assert_eq!(orig.zeta_up.to_bits(), round.zeta_up.to_bits());
+        assert_eq!(orig.g_lo.to_bits(), round.g_lo.to_bits());
+        assert_eq!(orig.s_lo.to_bits(), round.s_lo.to_bits());
+        assert_eq!(orig.g_up.to_bits(), round.g_up.to_bits());
+        assert_eq!(orig.s_up.to_bits(), round.s_up.to_bits());
     }
 }

--- a/src/models/laplace/multiscale.rs
+++ b/src/models/laplace/multiscale.rs
@@ -320,7 +320,13 @@ impl DistributionalForecaster for MultiScaleLaplace {
                     comps.push((scale_w * w, *g));
                 }
             }
-            out.push(GaussianMixture::new(comps));
+            // Prune the mixture-of-mixtures: each eligible scale
+            // contributes its full mixture components (up to ~30 per
+            // scale for .skaters()). Blended, that's easily 60-90
+            // components per horizon. Skaters' multiscale uses
+            // `max_components=20`; matching keeps quantile() bisection
+            // time bounded without meaningfully changing the density.
+            out.push(GaussianMixture::new(comps).prune(20));
         }
         Ok(out)
     }

--- a/tests/laplace_robustness.rs
+++ b/tests/laplace_robustness.rs
@@ -1,0 +1,205 @@
+//! Adversarial robustness suite — port of skaters' `rust/tests/robustness.rs`.
+//!
+//! Each test fits `LaplaceForecaster` to a hand-crafted problem series
+//! (constant, lattice, monster-spike, extreme-tick, scale-collapse,
+//! vol-whiplash) and asserts the resulting `GaussianMixture` per-horizon
+//! output is well-formed: finite `logpdf`, `cdf ∈ [0, 1]`, monotone
+//! finite quantiles.
+//!
+//! Adaptations from skaters:
+//! - Our API is batch (`fit` + `forecast_dist`), theirs is streaming
+//!   (`.step(y)`). We fit the full series once and check the final
+//!   forecast rather than checking every 997th step.
+//! - Skaters' full-forecaster serde round-trip is out of scope for us:
+//!   our `LaplaceForecaster` holds `Box<dyn Leaf>` (trait objects) that
+//!   aren't serde-derivable. Component serde is tested in
+//!   `src/models/laplace/dist.rs` and `gpd_tails.rs`.
+//! - Determinism check on `fit + forecast_dist` — same input,
+//!   bit-identical output.
+
+#![cfg(feature = "distributional")]
+
+use anofox_forecast::core::TimeSeries;
+use anofox_forecast::models::laplace::{
+    DistributionalForecaster, GaussianMixture, LaplaceForecaster,
+};
+use anofox_forecast::models::Forecaster;
+use chrono::{Duration, TimeZone, Utc};
+
+// -- helpers --
+
+/// Deterministic LCG matching skaters' adversarial harness.
+struct Lcg(u32);
+
+impl Lcg {
+    fn next(&mut self) -> f64 {
+        self.0 = self.0.wrapping_mul(1664525).wrapping_add(1013904223);
+        self.0 as f64 / 4_294_967_296.0
+    }
+
+    /// Box-Muller gaussian.
+    fn gauss(&mut self) -> f64 {
+        let mut u = 0.0;
+        while u == 0.0 {
+            u = self.next();
+        }
+        let mut v = 0.0;
+        while v == 0.0 {
+            v = self.next();
+        }
+        (-2.0 * u.ln()).sqrt() * (2.0 * std::f64::consts::PI * v).cos()
+    }
+}
+
+fn build_ts(values: Vec<f64>) -> TimeSeries {
+    let base = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let stamps: Vec<_> = (0..values.len())
+        .map(|i| base + Duration::seconds(i as i64))
+        .collect();
+    TimeSeries::univariate(stamps, values).expect("valid TimeSeries")
+}
+
+fn assert_wellformed(mix: &GaussianMixture, y_near: f64, label: &str) {
+    let lp = mix.logpdf(y_near);
+    assert!(!lp.is_nan(), "{label}: logpdf NaN");
+    let c = mix.cdf(y_near);
+    assert!((0.0..=1.0).contains(&c), "{label}: cdf out of range: {c}");
+    let ps = [0.001, 0.25, 0.5, 0.75, 0.999];
+    let qs: Vec<f64> = ps.iter().map(|&p| mix.quantile(p)).collect();
+    assert!(
+        qs.iter().all(|q| q.is_finite()),
+        "{label}: non-finite quantile in {qs:?}"
+    );
+    for w in qs.windows(2) {
+        assert!(w[1] >= w[0] - 1e-6, "{label}: quantiles unordered: {qs:?}");
+    }
+}
+
+fn soak(values: Vec<f64>, label: &str) {
+    let last = *values.last().expect("non-empty");
+    let ts = build_ts(values);
+    let mut f = LaplaceForecaster::new().auto();
+    f.fit(&ts).expect("fit");
+    let dists = f.forecast_dist(1).expect("forecast");
+    assert!(!dists.is_empty(), "{label}: empty forecast");
+    assert_wellformed(&dists[0], last, label);
+}
+
+// -- adversarial series --
+
+#[test]
+fn constant_series() {
+    soak(vec![3.7; 400], "constant");
+}
+
+#[test]
+fn lattice_series() {
+    let mut r = Lcg(17);
+    let mut v = 1.0;
+    let mut ys = Vec::new();
+    for _ in 0..600 {
+        if r.next() >= 0.7 {
+            let step = [-0.25, 0.25, 0.5][(r.next() * 3.0) as usize % 3];
+            v += step;
+        }
+        ys.push(v);
+    }
+    soak(ys, "lattice");
+}
+
+#[test]
+fn monster_spike_then_recovery() {
+    let mut r = Lcg(23);
+    let mut ys: Vec<f64> = (0..500).map(|_| r.gauss()).collect();
+    ys.push(1e9);
+    ys.extend((0..500).map(|_| r.gauss()));
+    soak(ys, "monster_spike");
+}
+
+#[test]
+fn extreme_finite_tick() {
+    let mut r = Lcg(29);
+    let mut ys: Vec<f64> = (0..400).map(|_| r.gauss()).collect();
+    ys.push(1e100); // 1e300 overflows YJ; 1e100 is still an extreme finite tick.
+    ys.extend((0..400).map(|_| r.gauss()));
+    soak(ys, "extreme_tick");
+}
+
+#[test]
+fn scale_collapse_and_recovery() {
+    let mut r = Lcg(31);
+    let mut ys: Vec<f64> = (0..400).map(|_| r.gauss()).collect();
+    ys.extend(std::iter::repeat_n(0.0, 400));
+    ys.extend((0..400).map(|_| r.gauss()));
+    soak(ys, "scale_collapse");
+}
+
+#[test]
+fn vol_whiplash_on_trend() {
+    let mut r = Lcg(41);
+    let mut lvl = 0.0;
+    let mut ys = Vec::new();
+    for t in 0..2000 {
+        let vol = if (t / 200) % 2 == 1 { 10.0 } else { 1.0 };
+        lvl += 0.05 + vol * r.gauss();
+        ys.push(lvl);
+    }
+    soak(ys, "vol_whiplash");
+}
+
+// -- bit-level determinism --
+
+#[test]
+fn bitwise_determinism_on_fit_forecast() {
+    // Same input series → bit-identical forecast_dist output. Runs
+    // twice from scratch, hashes logpdf/cdf/quantile at fixed points,
+    // asserts equality.
+    let run = || {
+        let mut r = Lcg(7);
+        let ys: Vec<f64> = (0..500).map(|_| r.gauss()).collect();
+        let ts = build_ts(ys);
+        let mut f = LaplaceForecaster::new().auto();
+        f.fit(&ts).unwrap();
+        let dists = f.forecast_dist(12).unwrap();
+        let mut acc: u64 = 0xcbf29ce484222325;
+        for d in &dists {
+            for v in [
+                d.logpdf(0.3),
+                d.cdf(0.3),
+                d.quantile(0.1),
+                d.mean(),
+                d.std(),
+            ] {
+                acc ^= v.to_bits();
+                acc = acc.wrapping_mul(0x100000001b3);
+            }
+        }
+        acc
+    };
+    assert_eq!(run(), run(), "two identical fit+forecast runs diverged");
+}
+
+#[test]
+fn bitwise_determinism_on_skaters_pool() {
+    // Same but with the wider .skaters() pool + our v0.15.3/4 knobs.
+    let run = || {
+        let mut r = Lcg(11);
+        let ys: Vec<f64> = (0..500).map(|_| r.gauss()).collect();
+        let ts = build_ts(ys);
+        let mut f = LaplaceForecaster::new()
+            .skaters()
+            .with_scoring_horizon(12)
+            .with_scoring_window(14);
+        f.fit(&ts).unwrap();
+        let dists = f.forecast_dist(12).unwrap();
+        let mut acc: u64 = 0xcbf29ce484222325;
+        for d in &dists {
+            for v in [d.logpdf(0.3), d.cdf(0.3), d.quantile(0.1)] {
+                acc ^= v.to_bits();
+                acc = acc.wrapping_mul(0x100000001b3);
+            }
+        }
+        acc
+    };
+    assert_eq!(run(), run(), "two identical .skaters() runs diverged");
+}


### PR DESCRIPTION
## Summary

Five skaters-parity improvements from their post-0.13.0 Rust port (microprediction/skaters#103). All measured neutral on fev-27 — this PR adds numerical stability, feature completeness, and test coverage, not accuracy.

## Added

1. **`dist::fsum`** — Neumaier-compensated summation. Wired into `GaussianMixture::new` / `mean` / `variance`. Skaters explicitly notes the plain `+=` accumulator diverges prune tie-breaks on long-tailed weighted sums.

2. **`GaussianMixture::prune(max_components)`** — closest-mean pair merge, port of skaters' `Dist::prune`. Wired into `MultiScaleLaplace::forecast_dist` at `max_components=20` (was previously emitting 60-90 components per horizon).

3. **`SplicedGaussianMixture`** type — full port of skaters' `SplicedDist`. Provides `.cdf`, `.pdf`, `.logpdf`, `.quantile`, plus numeric `.mean`/`.var`/`.std`/`.crps` via a 65-node quantile grid. New accessor `GpdTailsForecaster::spliced_mixtures(H) -> Vec<SplicedGaussianMixture>`.

4. **Serde bit-identity tests** on `Gaussian`, `GaussianMixture`, `GpdTailParams`. Skaters caught a real `serde_json` float roundtrip divergence via the same gate.

5. **Adversarial robustness suite** — port of skaters' `rust/tests/robustness.rs`. New `tests/laplace_robustness.rs` with 8 tests:
   - `constant_series`, `lattice_series`
   - `monster_spike_then_recovery`, `extreme_finite_tick`
   - `scale_collapse_and_recovery`, `vol_whiplash_on_trend`
   - `bitwise_determinism_on_fit_forecast`, `bitwise_determinism_on_skaters_pool`

   Each asserts the forecast mixture is well-formed (finite logpdf, cdf ∈ [0,1], monotone finite quantiles) after fitting on hand-crafted problem series. Catches regressions we currently miss.

## Fev-27 no-regression check (SAMPLE_PER=500)

- `.auto()`: MASE 5.9335 / WQL 0.1375 (bit-identical to v0.15.5)
- `.skaters()`: MASE 5.9658 / WQL 0.3005 (bit-identical to v0.15.5)

## Test plan
- [x] `cargo test --release --features "distributional serde" --lib` — 3062/3062 pass
- [x] `cargo test --release --features distributional --test laplace_robustness` — 8/8 pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] fev-27 A/B — bit-identical to v0.15.5
- [ ] Merge → v0.15.6 release triggers crates.io publish

## Not in scope (documented for future work)

Also from skaters#103, deferred:
- **Unified `Sk` enum** — architectural, ~1000 LOC. Enables full-forecaster serde, single composable product type. v0.16 candidate.
- **`laplace(k)` auto-composer** — one-call builder returning pre-composed forecaster. UX affordance.
- **Acklam `phi_inv` + `libm` bit-portability** — small numerical improvements. Could ship separately.
- **`spec` grammar, adaptive `search`, `cov/`, `grouped_ar`** — either rejected earlier (v0.15.4 review), out of scope (univariate), or uncertain value.
- **PyO3 Python bindings** — separate crate under `crates/anofox-forecast-py`. Only worth doing if you have Python demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)