### PR TITLE
Release v0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.6] - 2026-07-14
+
+Skaters-parity v2: numerical stability, feature completeness, adversarial test coverage. Ports five items from microprediction/skaters#103 (their Rust port PR). Zero behavior change on fev-27 — bit-identical MASE/WQL vs v0.15.5 on both `.auto()` and `.skaters()`.
+
+### Added
+
+- **`dist::fsum`** — Neumaier-compensated summation matching CPython 3.12+'s `sum()` and skaters' `mathx::fsum`. Wired into `GaussianMixture::new` (weight normalisation), `mean()`, and `variance()`. Fixes a subtle ~2-ULP drift on 20+ component mixtures that cascades into quantile-bisection differences (skaters flagged this as a source of prune tie-break divergence).
+- **`GaussianMixture::prune(max_components)`** — closest-mean pair merger, port of skaters' `Dist::prune`. Wired into `MultiScaleLaplace::forecast_dist` at `max_components=20` (matching skaters' `multiscale`). Previously the multi-scale blend could emit 60-90 components per horizon; pruning bounds quantile-bisection cost without meaningfully changing the density.
+- **`SplicedGaussianMixture`** type in `gpd_tails.rs` — full port of skaters' `SplicedDist`. Provides `.cdf`, `.pdf`, `.logpdf`, `.quantile`, plus numeric `.mean` / `.var` / `.std` / `.crps` via a cached 65-node quantile grid. New accessor `GpdTailsForecaster::spliced_mixtures(H) -> Vec<SplicedGaussianMixture>` completes the tail-splice API (previously only `.quantile_spliced()` was exposed).
+- **Serde bit-identity tests** on `Gaussian`, `GaussianMixture`, and `GpdTailParams` (also added missing `#[cfg_attr(serde, derive(...))]` on `GpdTailParams`). Skaters caught a real `serde_json` float roundtrip divergence via the same gate; we replicate the check.
+- **`tests/laplace_robustness.rs`** — port of skaters' `rust/tests/robustness.rs`. 8 adversarial tests (constant / lattice / monster-spike / extreme-tick / scale-collapse / vol-whiplash + two bitwise-determinism runs) exercising `LaplaceForecaster` on deliberately-hostile series. Each asserts finite `logpdf`, `cdf ∈ [0, 1]`, monotone finite quantiles at p ∈ {0.001, 0.25, 0.5, 0.75, 0.999}. Catches numerical regressions the fev-27 benchmark alone doesn't cover.
+
+### Fev-27 no-regression check (SAMPLE_PER=500)
+
+| Config | v0.15.5 | v0.15.6 | Δ |
+| :--- | ---: | ---: | ---: |
+| `.auto()` MASE | 5.9335 | 5.9335 | **0.0 %** (bit-identical) |
+| `.auto()` WQL | 0.1375 | 0.1375 | **0.0 %** |
+| `.skaters()` MASE | 5.9658 | 5.9658 | **0.0 %** |
+| `.skaters()` WQL | 0.3005 | 0.3005 | **0.0 %** |
+
+fsum changes only summation order (semantically identical), and prune only fires in the `MultiScaleLaplace` mixture-of-mixtures path.
+
+### Test-suite
+
+- Unit tests: 3006 → **3062** (added 6 dist / gpd_tails tests + 50 pre-existing serde-feature tests that now run under `--features serde`)
+- Integration tests: **+8** in `laplace_robustness.rs`
+- Clippy `--all-features -- -D warnings` clean
+
+### Documented in PR body as future work (deferred from skaters#103)
+
+- **Unified `Sk` enum** — architectural, ~1000 LOC. Enables full-forecaster serde, single composable product type. v0.16 candidate.
+- **`laplace(k)` auto-composer** — single-call builder returning pre-composed forecaster (CRPS + sticky + multiscale + tails). UX affordance.
+- **Acklam `phi_inv` + `libm` for cross-platform bit-parity** — small numerical improvements.
+- **PyO3 Python bindings** — separate crate. Only if there's Python demand.
+
+### Explicitly not planned
+
+- `spec` grammar (rejected v0.15.4 review)
+- Adaptive `search` (different design philosophy from our `.auto()` heuristic)
+- `cov/` (we're univariate)
+- `grouped_ar` (uncertain value)
+
 ## [0.15.5] - 2026-07-14
 
 Patch release to unblock the v0.15.4 crates.io publish, which was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Skaters-parity v2 release. Ships PR #208's five items:

1. `dist::fsum` (Neumaier-compensated summation)
2. `GaussianMixture::prune(N)` (closest-mean pair merger, wired into multiscale)
3. `SplicedGaussianMixture` type (full CDF/PDF/CRPS/moments)
4. Serde bit-identity tests on Gaussian / GaussianMixture / GpdTailParams
5. `tests/laplace_robustness.rs` — 8-test adversarial suite

## Fev-27 no-regression

Bit-identical to v0.15.5 on both `.auto()` (5.9335 / 0.1375) and `.skaters()` (5.9658 / 0.3005).

## Test plan
- [x] `cargo test --release --features "distributional serde" --lib` — 3062/3062 pass
- [x] `cargo test --release --features distributional --test laplace_robustness` — 8/8 pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [ ] Merge → GH release triggers crates.io + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)