### PR TITLE
fix(laplace): GARCH init on large-scale data — cures WQL blowup on cif_2016/m1_yearly/tourism_yearly

### DIFF
--- a/examples/wql_outlier_diagnosis.rs
+++ b/examples/wql_outlier_diagnosis.rs
@@ -1,0 +1,200 @@
+//! Diagnose the m1_yearly / cif_2016 / tourism_yearly WQL outlier
+//! pathology. Loads each dataset, fits a few LaplaceForecaster variants
+//! per series, and prints the WQL contributions per series so we can
+//! see which series drive the aggregate blowup.
+//!
+//! Run: `cargo run --release --features distributional --example wql_outlier_diagnosis`
+
+use anofox_forecast::core::TimeSeries;
+use anofox_forecast::models::laplace::{DistributionalForecaster, LaplaceForecaster};
+use anofox_forecast::models::Forecaster;
+use chrono::{Duration, TimeZone, Utc};
+use std::fs;
+
+const WQL_QS: [f64; 9] = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+
+fn wql(matrix: &[Vec<f64>], y: &[f64]) -> f64 {
+    let denom: f64 = y.iter().map(|v| v.abs()).sum::<f64>().max(1e-9);
+    let mut total = 0.0;
+    for (qi, &q) in WQL_QS.iter().enumerate() {
+        for (h, &yy) in y.iter().enumerate() {
+            let qhat = matrix[qi][h];
+            let e = yy - qhat;
+            let pinball = if e > 0.0 { q * e } else { (q - 1.0) * e };
+            total += 2.0 * pinball;
+        }
+    }
+    total / denom
+}
+
+fn mixture_stats(
+    model: &mut LaplaceForecaster,
+    _ts: &TimeSeries,
+    h: usize,
+    y: &[f64],
+) -> (f64, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+    let dists = model.forecast_dist(h).unwrap();
+    let matrix: Vec<Vec<f64>> = WQL_QS
+        .iter()
+        .map(|&q| dists.iter().map(|g| g.quantile(q)).collect())
+        .collect();
+    let w = wql(&matrix, y);
+    let means: Vec<f64> = dists.iter().map(|g| g.mean()).collect();
+    let stds: Vec<f64> = dists.iter().map(|g| g.std()).collect();
+    let q05: Vec<f64> = dists.iter().map(|g| g.quantile(0.05)).collect();
+    let q95: Vec<f64> = dists.iter().map(|g| g.quantile(0.95)).collect();
+    (w, means, stds, q05, q95)
+}
+
+fn load_series(path: &str, min_len: usize) -> Vec<Vec<f64>> {
+    // Match examples/fev_benchmark.rs parse_tsf — bytes-as-chars to tolerate
+    // non-UTF-8 TSF files.
+    let bytes = fs::read(path).unwrap_or_default();
+    let content: String = bytes.iter().map(|&b| b as char).collect();
+    let mut series = Vec::new();
+    let mut in_data = false;
+    for line in content.lines() {
+        if !in_data {
+            if line.trim_start().starts_with("@data") {
+                in_data = true;
+            }
+            continue;
+        }
+        let toks: Vec<&str> = line.split(':').collect();
+        if toks.len() < 2 {
+            continue;
+        }
+        let vals_str = toks[toks.len() - 1];
+        let values: Vec<f64> = vals_str
+            .split(',')
+            .filter_map(|tok| tok.trim().parse::<f64>().ok())
+            .collect();
+        if values.len() >= min_len {
+            series.push(values);
+        }
+    }
+    series
+}
+
+fn run(dataset: &str, path: &str, horizon: usize) {
+    println!("\n==== {dataset} (horizon={horizon}) ====");
+    let series = load_series(path, horizon + 10);
+    println!("loaded {} series", series.len());
+    let base = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let mut auto_wqls = Vec::new();
+    let mut skaters_wqls = Vec::new();
+    let mut nosticky_wqls = Vec::new();
+    let mut worst_details: Vec<(
+        usize,
+        f64,
+        f64,
+        f64,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    )> = Vec::new();
+    for (idx, values) in series.iter().enumerate().take(500) {
+        let split = values.len() - horizon;
+        let train_v = values[..split].to_vec();
+        let test_v: Vec<f64> = values[split..].to_vec();
+        let stamps: Vec<_> = (0..train_v.len())
+            .map(|i| base + Duration::days(i as i64))
+            .collect();
+        let train_ts = TimeSeries::univariate(stamps, train_v).unwrap();
+
+        let mut m_auto = LaplaceForecaster::new().auto();
+        m_auto.fit(&train_ts).unwrap();
+        let (w_auto, means_a, stds_a, _, _) =
+            mixture_stats(&mut m_auto, &train_ts, horizon, &test_v);
+        auto_wqls.push(w_auto);
+
+        let mut m_skaters = LaplaceForecaster::new().skaters();
+        m_skaters.fit(&train_ts).unwrap();
+        let (w_skaters, means_s, stds_s, q05_s, q95_s) =
+            mixture_stats(&mut m_skaters, &train_ts, horizon, &test_v);
+        skaters_wqls.push(w_skaters);
+
+        let mut m_nosticky = LaplaceForecaster::new().skaters().no_sticky();
+        m_nosticky.fit(&train_ts).unwrap();
+        let (w_nosticky, _, _, _, _) = mixture_stats(&mut m_nosticky, &train_ts, horizon, &test_v);
+        nosticky_wqls.push(w_nosticky);
+
+        worst_details.push((
+            idx, w_auto, w_skaters, w_nosticky, means_a, means_s, stds_a, stds_s, q05_s, q95_s,
+            test_v,
+        ));
+    }
+    // Sort by skaters WQL descending — worst first.
+    worst_details.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap());
+    println!("\nTop 5 worst .skaters() WQL series (mixture inspection):");
+    for row in &worst_details[..worst_details.len().min(5)] {
+        let (idx, wa, ws, wn, means_a, means_s, stds_a, stds_s, q05_s, q95_s, test_v) = row;
+        println!("\n--- series {idx}: WQL auto={wa:.4}, skaters={ws:.4}, +nosticky={wn:.4} ---");
+        for h in 0..test_v.len() {
+            let width_a = stds_a[h] * 2.0;
+            let width_s = q95_s[h] - q05_s[h];
+            println!(
+                "  h={:2} y={:>12.2}   auto: μ={:>12.2} σ={:>10.3}    skaters: μ={:>12.2} σ={:>10.3} [q05={:>12.2}, q95={:>12.2}]  width_ratio={:.2}",
+                h + 1, test_v[h],
+                means_a[h], stds_a[h],
+                means_s[h], stds_s[h],
+                q05_s[h], q95_s[h],
+                if width_a > 0.0 { width_s / width_a } else { 0.0 },
+            );
+        }
+    }
+    // Aggregate.
+    let sum = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+    println!(
+        "\nMean per-series WQL: auto={:.4} skaters={:.4} skaters+nosticky={:.4}",
+        sum(&auto_wqls),
+        sum(&skaters_wqls),
+        sum(&nosticky_wqls),
+    );
+}
+
+fn dump_per_leaf(path: &str, series_idx: usize, horizon: usize) {
+    let series = load_series(path, horizon + 10);
+    let values = &series[series_idx];
+    let split = values.len() - horizon;
+    let train_v = values[..split].to_vec();
+    let y_scale: f64 = train_v
+        .iter()
+        .map(|v| v.abs())
+        .fold(0.0f64, f64::max)
+        .max(1e-9);
+    let base = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let stamps: Vec<_> = (0..train_v.len())
+        .map(|i| base + Duration::days(i as i64))
+        .collect();
+    let train_ts = TimeSeries::univariate(stamps, train_v).unwrap();
+    let mut m = LaplaceForecaster::new().skaters();
+    m.fit(&train_ts).unwrap();
+    println!("\n=== per-leaf predict_one() dump for {path}[{series_idx}] ===");
+    println!("y_scale (max |y|) = {y_scale:.3e}");
+    let leaves = m.debug_leaf_predictions();
+    let mut rows: Vec<_> = leaves.into_iter().collect();
+    // Sort by std descending — divergent leaves at the top.
+    rows.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap());
+    println!(
+        "{:<40} {:>10} {:>14} {:>14} {:>10}",
+        "leaf", "weight", "mean", "std", "std/y_scale"
+    );
+    for (name, mu, s, w) in rows.iter().take(20) {
+        let ratio = s / y_scale;
+        let flag = if ratio > 1000.0 { " ← DIVERGED" } else { "" };
+        println!("{name:<40} {w:>10.6} {mu:>14.2e} {s:>14.2e} {ratio:>10.2e}{flag}");
+    }
+}
+
+fn main() {
+    run("m1_yearly", "validation/data/m1_yearly.tsf", 6);
+    run("tourism_yearly", "validation/data/tourism_yearly.tsf", 4);
+    run("cif_2016", "validation/data/cif_2016.tsf", 12);
+    // Culprit-finding: which leaf emits absurd σ?
+    dump_per_leaf("validation/data/cif_2016.tsf", 54, 12);
+}

--- a/src/models/laplace/forecaster.rs
+++ b/src/models/laplace/forecaster.rs
@@ -980,6 +980,15 @@ pub struct LaplaceForecaster {
     /// Filled by fit() when parade_horizon is set.
     /// Length `parade_horizon`; each element is `~ N_train - h` PITs.
     parade_pit: Vec<Vec<f64>>,
+    /// v0.15.7: optional diffuse background component (skaters#72).
+    /// `Some((eps, sigma_factor))` means every forecast mixture gains a
+    /// tiny broad Gaussian `(eps · sigma_factor · residuals_std)` centred
+    /// on the mixture mean. Floors worst-case log-loss on outliers
+    /// without touching interior densities on continuous series.
+    diffuse_background: Option<(f64, f64)>,
+    /// Sigma of the diffuse background, computed at fit time from
+    /// `sigma_factor * std(training residuals)`.
+    diffuse_sigma_bg: Option<f64>,
     /// Accuracy-audit #1 (ensemble stacking): enable OLS-based blend
     /// weight learning at end of fit. When true and enough training data
     /// is available, `stacking_weights` is populated with per-leaf
@@ -1095,6 +1104,8 @@ impl LaplaceForecaster {
             scoring_window_hist: Vec::new(),
             parade_horizon: None,
             parade_pit: Vec::new(),
+            diffuse_background: None,
+            diffuse_sigma_bg: None,
         }
     }
 
@@ -1246,6 +1257,26 @@ impl LaplaceForecaster {
         self
     }
 
+    /// Debug: per-leaf `(name, mean, std, weight)` at h=1 after fit.
+    /// Weight is the current softmax weight; mean/std are the leaf's
+    /// own `predict_one()` output, BEFORE terminal / YJ / sticky
+    /// post-processing. Used by
+    /// `examples/wql_outlier_diagnosis.rs` to identify numerical
+    /// divergence in individual leaves.
+    #[doc(hidden)]
+    pub fn debug_leaf_predictions(&self) -> Vec<(&'static str, f64, f64, f64)> {
+        let weights = self.weights();
+        self.leaves
+            .iter()
+            .enumerate()
+            .map(|(i, l)| {
+                let g = l.predict_one();
+                let w = weights.get(i).copied().unwrap_or(0.0);
+                (l.name(), g.mean, g.std, w)
+            })
+            .collect()
+    }
+
     /// Per-horizon PIT values collected during fit. `None` unless
     /// [`Self::with_parade`] was set; `Some(&[Vec<f64>; k])` after fit.
     pub fn parade_pit(&self) -> Option<&[Vec<f64>]> {
@@ -1254,6 +1285,35 @@ impl LaplaceForecaster {
         } else {
             None
         }
+    }
+
+    /// Optional diffuse background component (skaters#72).
+    ///
+    /// Adds a tiny broad Gaussian to every `forecast_dist(h)` mixture:
+    /// weight `eps`, mean = mixture mean, sigma = `sigma_factor · σ_residuals`.
+    /// After the mixture re-normalises, the background's weight is
+    /// `eps / (1 + eps)`, so continuous-series densities are essentially
+    /// unchanged (default `eps = 1e-4` costs < 1e-4 nats on the bulk).
+    ///
+    /// **Effect on outliers**: worst-case `logpdf(y)` is now bounded
+    /// below by `log(eps) + logN(y | μ, σ_bg)`. On a series where a
+    /// mixture component's tight scale would otherwise produce a
+    /// catastrophic `logpdf ≈ −1e10` on an off-grid outcome, the loss
+    /// is capped at ~`log(eps) − 0.5(y − μ)² / σ_bg² − log(σ_bg)`
+    /// (typically −10 to −20 nats), rescuing the mean log-loss and
+    /// per-series WQL scores.
+    ///
+    /// Target: our known WQL outlier catastrophes on continuous smooth
+    /// panels (m1_yearly 98× baseline, tourism_yearly 100×, cif_2016
+    /// 45000×) — sticky-lattice atoms placed on continuous data cause
+    /// exactly the "one off-grid outcome dominates" pathology this
+    /// backstop is designed for.
+    ///
+    /// **Defaults**: `eps = 1e-4`, `sigma_factor = 10.0`. Opt-in only;
+    /// no effect until `.with_diffuse_background(_, _)` is called.
+    pub fn with_diffuse_background(mut self, eps: f64, sigma_factor: f64) -> Self {
+        self.diffuse_background = Some((eps.max(1e-12), sigma_factor.max(1e-3)));
+        self
     }
 
     /// Enable ensemble stacking on top of the softmax blend
@@ -3456,6 +3516,22 @@ impl Forecaster for LaplaceForecaster {
             }
             self.calibration_scale_per_h = per_h;
         }
+        // Diffuse-background fit-time init (skaters#72): compute σ_bg
+        // from training-residual RMS × user's sigma_factor. Used by
+        // `forecast_dist` to append the tiny broad component to each
+        // per-horizon mixture.
+        if let Some((_, sigma_factor)) = self.diffuse_background {
+            let n = self.residuals.len().max(1) as f64;
+            let mean: f64 = self.residuals.iter().copied().sum::<f64>() / n;
+            let var: f64 = self
+                .residuals
+                .iter()
+                .map(|r| (r - mean).powi(2))
+                .sum::<f64>()
+                / n;
+            let sigma = var.sqrt().max(1e-9) * sigma_factor;
+            self.diffuse_sigma_bg = Some(sigma);
+        }
         Ok(())
     }
 
@@ -3648,8 +3724,29 @@ impl DistributionalForecaster for LaplaceForecaster {
                 // exact values. No-op if no atoms have fired. Fix A of
                 // fev-27 follow-up: horizon-decayed atom mass (`h + 1`
                 // since the closure's `h` is 0-based).
-                if let Some(s) = self.sticky.as_ref() {
+                let mix = if let Some(s) = self.sticky.as_ref() {
                     s.project(&mix, h + 1)
+                } else {
+                    mix
+                };
+                // Skaters#72 diffuse-background floor: append a tiny
+                // broad Gaussian at the mixture mean with sigma =
+                // sigma_factor · σ_residuals. Weight after re-normalise
+                // is eps/(1+eps) — negligible on the bulk, but places
+                // a hard floor of log(eps) − 0.5·(y − μ)²/σ_bg² −
+                // log(σ_bg) on the tail log-loss. Zero-cost when
+                // `.with_diffuse_background(...)` wasn't called.
+                if let (Some((eps, _)), Some(sigma_bg)) =
+                    (self.diffuse_background, self.diffuse_sigma_bg)
+                {
+                    if !mix.is_empty() {
+                        let mu = mix.mean();
+                        let mut comps = mix.components.clone();
+                        comps.push((eps, super::dist::Gaussian::new(mu, sigma_bg)));
+                        GaussianMixture::new(comps)
+                    } else {
+                        mix
+                    }
                 } else {
                     mix
                 }

--- a/src/models/laplace/leaves/garch.rs
+++ b/src/models/laplace/leaves/garch.rs
@@ -97,11 +97,20 @@ impl Leaf for GarchWrappedLeaf {
         if !self.initialized {
             // Bootstrap: use unconditional variance if stationary.
             let persist = self.alpha + self.beta;
-            self.var = if persist < 1.0 {
+            let unconditional = if persist < 1.0 {
                 self.omega / (1.0 - persist)
             } else {
                 self.omega
             };
+            // FLOOR by y² so the very first standardized value stays
+            // O(1) regardless of input scale. Without this floor,
+            // `omega/(1-persist)` is a tiny constant (~5e-5) that on
+            // billion-scale input produces `y / sigma ≈ 2e11`,
+            // poisoning the inner EMA for many observations. Diagnosed
+            // on cif_2016 series 54 where this cascaded into a
+            // 60-million-times mixture-σ inflation via the terminal
+            // residual EWMA.
+            self.var = unconditional.max(y * y);
             self.last_y = y;
             self.initialized = true;
             let sigma = self.conditional_sigma();

--- a/tests/laplace_robustness.rs
+++ b/tests/laplace_robustness.rs
@@ -179,6 +179,55 @@ fn bitwise_determinism_on_fit_forecast() {
     assert_eq!(run(), run(), "two identical fit+forecast runs diverged");
 }
 
+/// Port of skaters issue microprediction/skaters#86:
+/// for integrated transforms, predictive variance should be nondecreasing
+/// in horizon `h`. `MultiScaleLaplace` mixes coarse-clock forecasts at
+/// stride boundaries `{1, period, k}` — verify no "variance sawtooth"
+/// on a random walk (worst-case integrated series).
+#[test]
+fn multiscale_variance_is_monotone_in_horizon_on_random_walk() {
+    use anofox_forecast::models::laplace::MultiScaleLaplace;
+    // 500 obs of a Gaussian random walk — variance should scale as h.
+    let mut r = Lcg(53);
+    let mut lvl = 0.0;
+    let ys: Vec<f64> = (0..500)
+        .map(|_| {
+            lvl += r.gauss();
+            lvl
+        })
+        .collect();
+    let ts = build_ts(ys);
+    const H: usize = 30;
+    let mut m = MultiScaleLaplace::skaters(H);
+    m.fit(&ts).expect("fit");
+    let dists = m.forecast_dist(H).expect("forecast");
+    assert_eq!(dists.len(), H);
+    // Weak monotonicity — allow a small numerical epsilon at scale
+    // boundaries but flag anything egregious.
+    let vars: Vec<f64> = dists.iter().map(|d| d.variance()).collect();
+    let mut violations: Vec<String> = Vec::new();
+    for h in 1..H {
+        let ratio = vars[h] / vars[h - 1];
+        // Downward jumps of more than 5% at a boundary = sawtooth
+        if ratio < 0.95 {
+            violations.push(format!(
+                "  h={}: var[{}]={:.3} > var[{}]={:.3} (ratio={:.3})",
+                h,
+                h - 1,
+                vars[h - 1],
+                h,
+                vars[h],
+                ratio
+            ));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "MultiScaleLaplace variance sawtooth on random walk (skaters#86):\n{}",
+        violations.join("\n")
+    );
+}
+
 #[test]
 fn bitwise_determinism_on_skaters_pool() {
     // Same but with the wider .skaters() pool + our v0.15.3/4 knobs.


### PR DESCRIPTION
## Summary

Diagnosed and fixed the WQL blowup pathology that has haunted `.skaters()` on continuous large-scale panels since v0.13.0 (documented in `docs/SOTA_POSITIONING.md`).

## Root cause

`GarchWrappedLeaf::observe` on the very first observation initialised `var` from the tiny stationary-unconditional variance (`omega/(1-persist)` ≈ 5e-5). On billion-scale inputs this produced `y/sigma ≈ 2e11`, poisoning the inner EMA for many observations. That leaf's diverged predictions (mean = 7.89e17 on cif_2016 series 54!) then contaminated the terminal scale-mixture's residual EWMA, cascading into 60-million-times-inflated mixture sigmas.

Diagnosed via new `examples/wql_outlier_diagnosis.rs`:

```
=== per-leaf predict_one() dump for cif_2016[54] ===
y_scale (max |y|) = 1.486e9
leaf                weight       mean          std   std/y_scale
ema@garch         0.000000   7.89e17    1.04e18    6.98e8 ← DIVERGED
```

## Fix

One line in `GarchWrappedLeaf::observe`:

```rust
// Was:
self.var = if persist < 1.0 { self.omega / (1.0 - persist) } else { self.omega };

// Now:
let unconditional = if persist < 1.0 { self.omega / (1.0 - persist) } else { self.omega };
self.var = unconditional.max(y * y);  // FLOOR by y² so first standardized value is O(1)
```

## Measurement (fev-27, SAMPLE_PER=500)

### Per-dataset WQL (the problem datasets)

| Dataset | Before | After | Δ |
|---|---:|---:|---:|
| **m1_yearly** | **98.35** | **0.165** | **~600× improvement** |
| **tourism_yearly** | **5.505** | **0.240** | **~23× improvement** |
| **cif_2016** | **45314** | **0.148** | **~300000× improvement** |

### Aggregate

| Config | Metric | v0.15.6 | This PR | Δ |
|---|---|---:|---:|---:|
| `.auto()` | MASE | 5.9335 | 5.9335 | 0.0 % (unchanged) |
| `.auto()` | WQL | 0.1375 | 0.1375 | 0.0 % |
| `.skaters()` | MASE | 5.9658 | 5.9619 | −0.07 % |
| **`.skaters()`** | **WQL** | **0.3005** | **0.1336** | **−55.5 %** |

`.skaters()` is now competitive with `.auto()` on WQL for the first time.

## Also in this PR

- **`LaplaceForecaster::with_diffuse_background(eps, sigma_factor)`** — port of skaters#72 (optional log-loss floor). Works as designed but measured neutral on fev-27 WQL (metric mismatch: WQL uses q ∈ [0.1, 0.9], diffuse bg affects extreme tail). Shipped as opt-in for log-score callers.
- **`LaplaceForecaster::debug_leaf_predictions()`** — hidden `#[doc(hidden)]` diagnostic method used by the outlier-diagnosis example.
- **`tests/laplace_robustness.rs::multiscale_variance_is_monotone_in_horizon_on_random_walk`** — port of skaters issue #86 defensive test. Passes.
- **`examples/wql_outlier_diagnosis.rs`** — reusable per-leaf diagnostic tool.

## Test plan
- [x] `cargo test --release --features "distributional serde" --lib` — 3062/3062 pass
- [x] `cargo test --release --features distributional --test laplace_robustness` — 9/9 pass
- [x] `cargo test --release --features distributional --lib garch` — 43/43 pass (GARCH tests still green after init change)
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] fev-27 A/B — shows −55.5 % WQL on `.skaters()` aggregate
- [ ] Merge → v0.15.7 release triggers crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)