### PR TITLE
Release v0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.7] - 2026-07-14
+
+Bug-fix release with a headline WQL improvement. A one-line `GarchWrappedLeaf::observe` init bug caused **60-million-times mixture-σ inflation** on billion-scale continuous data via poison of the terminal residual EWMA. Fixed; per-dataset WQL drops of **~600× on m1_yearly, ~23× on tourism_yearly, ~300000× on cif_2016**.
+
+### Fixed
+
+- **`GarchWrappedLeaf::observe`** on first observation now floors initial `var` by `y²` so the first standardised value is `O(1)` regardless of input scale. Previously the unconditional variance `omega / (1 - persist)` ≈ 5e-5 produced `y / sigma ≈ 2e11` on billion-scale inputs, poisoning the inner EMA for many observations. That leaf's diverged predictions (mean = 7.89e17 on cif_2016 series 54 despite ~0 softmax weight) then contaminated the terminal scale-mixture's residual EWMA, cascading into 60-million-times-inflated mixture sigmas across the whole final mixture.
+
+  Diagnosed via new `examples/wql_outlier_diagnosis.rs` — sticky lattice, GPD tails, diffuse background were all ruled out first via direct A/B before the per-leaf sweep found the divergent `ema@garch` leaf.
+
+### Added
+
+- **`LaplaceForecaster::with_diffuse_background(eps, sigma_factor)`** — port of skaters#72 (optional log-loss floor via a tiny broad Gaussian on every forecast mixture). Works as designed. Measured neutral on fev-27 WQL (metric mismatch: WQL uses q ∈ [0.1, 0.9], diffuse bg affects extreme tail). Shipped as opt-in for log-score callers (Bayesian model comparison, information-theoretic diagnostics).
+- **`LaplaceForecaster::debug_leaf_predictions()`** — `#[doc(hidden)]` diagnostic returning per-leaf `(name, mean, std, weight)` for the current state. Used by `examples/wql_outlier_diagnosis.rs` and `examples/leaf_init_pathology_sweep.rs`.
+- **`examples/wql_outlier_diagnosis.rs`** — reusable diagnostic for per-series / per-leaf WQL investigation.
+- **`examples/leaf_init_pathology_sweep.rs`** — permanent regression guard. Instantiates each of 19 leaf variants on billion-scale data and flags any that peak `>> y_scale` on early observations. Would catch a future GARCH-style init bug immediately.
+- **`tests/laplace_robustness.rs::multiscale_variance_is_monotone_in_horizon_on_random_walk`** — port of skaters issue #86 defensive test. Verifies no variance sawtooth at `MultiScaleLaplace` stride boundaries.
+
+### Fev-27 measurement (SAMPLE_PER=500)
+
+**Per-dataset WQL** (the previously-catastrophic datasets):
+
+| Dataset | v0.15.6 | v0.15.7 | Δ |
+| :--- | ---: | ---: | ---: |
+| **m1_yearly** | 98.35 | **0.165** | **~600× improvement** |
+| **tourism_yearly** | 5.505 | **0.240** | **~23× improvement** |
+| **cif_2016** | 45314 | **0.148** | **~300000× improvement** |
+
+**Aggregate**:
+
+| Config | Metric | v0.15.6 | v0.15.7 | Δ |
+| :--- | :--- | ---: | ---: | ---: |
+| `.auto()` | MASE | 5.9335 | 5.9335 | 0.0 % (unchanged; auto doesn't use GARCH-wrapped leaves) |
+| `.auto()` | WQL | 0.1375 | 0.1375 | 0.0 % |
+| `.skaters()` | MASE | 5.9658 | 5.9619 | −0.07 % |
+| **`.skaters()`** | **WQL** | **0.3005** | **0.1336** | **−55.5 %** |
+
+`.skaters()` is WQL-competitive with `.auto()` for the first time in project history.
+
+### Investigation notes (not shipped)
+
+- **Adaptive search port** (skaters `search`): measured against our stack via python skaters `search(k=H)` A/B on cif_2016 / tourism_monthly / m4_hourly. Their `search` was 25-199 % worse than our `MultiScaleLaplace + scH + scW` on all three. Not worth the ~500 LOC + 7 hyperparameters.
+- **Per-leaf init pathology sweep** on all 19 leaves in `.skaters()` pool. Found only the GARCH bug; every other leaf peaks correctly at `≤ y_scale` on obs 1 and converges. No more low-hanging fruit.
+
 ## [0.15.6] - 2026-07-14
 
 Skaters-parity v2: numerical stability, feature completeness, adversarial test coverage. Ports five items from microprediction/skaters#103 (their Rust port PR). Zero behavior change on fev-27 — bit-identical MASE/WQL vs v0.15.5 on both `.auto()` and `.skaters()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anofox-regression",
  "anofox-statistics",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast-js"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anofox-forecast",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "anofox-forecast"
-version = "0.15.6"
+version = "0.15.7"
 edition = "2021"
 authors = ["Simon Müller"]
 description = "Time series forecasting library"

--- a/crates/anofox-forecast-js/Cargo.toml
+++ b/crates/anofox-forecast-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anofox-forecast-js"
-version = "0.15.6"
+version = "0.15.7"
 edition = "2021"
 authors = ["Simon M"]
 description = "WebAssembly bindings for anofox-forecast time series forecasting library"

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
     "Simon M"
   ],
   "description": "WebAssembly bindings for anofox-forecast time series forecasting library",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bug-fix release. Headline: **one-line GARCH init fix cures the WQL blowup pathology** documented in `docs/SOTA_POSITIONING.md` since v0.13.0.

## Per-dataset WQL

| Dataset | v0.15.6 | v0.15.7 | Δ |
|---|---:|---:|---:|
| **m1_yearly** | 98.35 | **0.165** | ~600× improvement |
| **tourism_yearly** | 5.505 | **0.240** | ~23× improvement |
| **cif_2016** | 45314 | **0.148** | **~300000× improvement** |

## Aggregate

- `.auto()`: unchanged (doesn't use GARCH-wrapped leaves)
- **`.skaters()` WQL**: 0.3005 → **0.1336** (**−55.5 %**). WQL-competitive with `.auto()` for the first time.

## Also in this release

- `LaplaceForecaster::with_diffuse_background()` — skaters#72 opt-in log-loss floor
- `debug_leaf_predictions()` + `examples/wql_outlier_diagnosis.rs` + `examples/leaf_init_pathology_sweep.rs`
- Multiscale variance monotonicity test (skaters#86)

## Test plan
- [x] `cargo test --release --features "distributional serde" --lib` — 3062/3062 pass
- [x] `cargo test --release --features distributional --test laplace_robustness` — 9/9 pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [ ] Merge → GH release triggers crates.io + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)